### PR TITLE
Upping package versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "atom-ungit",
-  "version": "0.5.3",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,11 +10,11 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "accepts": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
-      "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "2.1.17",
+        "mime-types": "2.1.18",
         "negotiator": "0.6.1"
       }
     },
@@ -24,12 +24,12 @@
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
     },
     "ajv": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
-      "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
         "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
+        "fast-deep-equal": "1.1.0",
         "fast-json-stable-stringify": "2.0.0",
         "json-schema-traverse": "0.3.1"
       }
@@ -46,13 +46,13 @@
       "optional": true
     },
     "are-we-there-yet": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "optional": true,
       "requires": {
         "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "isarray": {
@@ -62,24 +62,24 @@
           "optional": true
         },
         "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "optional": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
             "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
+            "process-nextick-args": "2.0.0",
             "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
+            "string_decoder": "1.1.1",
             "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "optional": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -93,9 +93,9 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "arraybuffer.slice": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
-      "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco="
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
     },
     "asn1": {
       "version": "0.2.3",
@@ -108,12 +108,9 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "async": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-      "requires": {
-        "lodash": "4.17.4"
-      }
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
     },
     "async-limiter": {
       "version": "1.0.0",
@@ -126,11 +123,12 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atom-space-pen-views": {
-      "version": "https://registry.npmjs.org/atom-space-pen-views/-/atom-space-pen-views-2.2.0.tgz",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/atom-space-pen-views/-/atom-space-pen-views-2.2.0.tgz",
       "integrity": "sha1-plsskg7QL3JAFPp9Plw9ePv1mZc=",
       "requires": {
-        "fuzzaldrin": "https://registry.npmjs.org/fuzzaldrin/-/fuzzaldrin-2.1.0.tgz",
-        "space-pen": "https://registry.npmjs.org/space-pen/-/space-pen-5.1.2.tgz"
+        "fuzzaldrin": "2.1.0",
+        "space-pen": "5.1.2"
       }
     },
     "aws-sign2": {
@@ -139,9 +137,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
     },
     "backo2": {
       "version": "1.0.2",
@@ -196,38 +194,35 @@
       "integrity": "sha512-EkNUOi7tpV68TqjpiUz9D9NcT8um2+qtgntmMbi5UKssVX2m/2PLqotcric0RE63pB3HPN/fjf3cKHN2ufGSUQ=="
     },
     "body-parser": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
       "requires": {
         "bytes": "3.0.0",
         "content-type": "1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.1",
-        "http-errors": "1.6.2",
-        "iconv-lite": "0.4.19",
+        "depd": "1.1.2",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
         "on-finished": "2.3.0",
-        "qs": "6.5.1",
-        "raw-body": "2.3.2",
-        "type-is": "1.6.15"
-      }
-    },
-    "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "requires": {
-        "hoek": "4.2.0"
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
+        "type-is": "1.6.16"
       }
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "buffer-from": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -259,14 +254,48 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
     "cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
         "wrap-ansi": "2.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
       }
     },
     "clone": {
@@ -285,33 +314,33 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "color": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color/-/color-2.0.1.tgz",
-      "integrity": "sha512-ubUCVVKfT7r2w2D3qtHakj8mbmKms+tThR8gI8zEYCbUBl8/voqFGt3kgBqGwXAopgXybnkuOq+qMYCRrp4cXw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
       "requires": {
-        "color-convert": "1.9.1",
+        "color-convert": "1.9.2",
         "color-string": "1.5.2"
       }
     },
     "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "1.1.1"
       }
     },
     "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
     },
     "color-string": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
       "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
       "requires": {
-        "color-name": "1.1.3",
+        "color-name": "1.1.1",
         "simple-swizzle": "0.2.2"
       }
     },
@@ -349,12 +378,13 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
+        "buffer-from": "1.1.0",
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.6",
         "typedarray": "0.0.6"
       },
       "dependencies": {
@@ -364,23 +394,23 @@
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
             "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
+            "process-nextick-args": "2.0.0",
             "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
+            "string_decoder": "1.1.1",
             "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -441,9 +471,9 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "4.1.1",
+        "lru-cache": "4.1.3",
         "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "which": "1.3.1"
       }
     },
     "crossroads": {
@@ -454,23 +484,10 @@
         "signals": "1.0.0"
       }
     },
-    "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        }
-      }
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "cycle": {
       "version": "1.0.3",
@@ -478,10 +495,11 @@
       "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
     },
     "d": {
-      "version": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
       "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
       "requires": {
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
+        "es5-ext": "0.10.45"
       }
     },
     "dashdash": {
@@ -506,9 +524,9 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "deep-extend": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "delayed-stream": {
       "version": "0.0.5",
@@ -522,9 +540,9 @@
       "optional": true
     },
     "depd": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "destroy": {
       "version": "1.0.4",
@@ -532,28 +550,33 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "diff": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
-      "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
     },
     "diff2html": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/diff2html/-/diff2html-2.3.2.tgz",
-      "integrity": "sha1-HFhkJm1DcUi8Zv3WbUrXUBAtf+0=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/diff2html/-/diff2html-2.3.3.tgz",
+      "integrity": "sha1-MbuBWIHJdWNMfzkHpeeJNB4VYLw=",
       "requires": {
-        "diff": "3.4.0",
+        "diff": "3.5.0",
         "hogan.js": "3.0.2",
-        "lodash": "4.17.4",
-        "whatwg-fetch": "2.0.3"
+        "lodash": "4.17.10",
+        "whatwg-fetch": "2.0.4"
       }
+    },
+    "dnd-page-scroll": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/dnd-page-scroll/-/dnd-page-scroll-0.0.4.tgz",
+      "integrity": "sha512-bvjUS5Cylrm1uJJop/dFhEpnYtz2NQFOO0/z6vk0ORtx0AqKvUwPToc4reJk+TnHV9GBxbtZXj7ad5dJT/Dqkg=="
     },
     "eachr": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/eachr/-/eachr-3.2.0.tgz",
       "integrity": "sha1-LDXkPqCGUW95l8+At6pk1VpKRIQ=",
       "requires": {
-        "editions": "1.3.3",
-        "typechecker": "4.4.1"
+        "editions": "1.3.4",
+        "typechecker": "4.5.0"
       }
     },
     "ecc-jsbn": {
@@ -566,9 +589,9 @@
       }
     },
     "editions": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.3.tgz",
-      "integrity": "sha1-CQcQG92iD6w8vjNMJ8vQaI3Jmls="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
     },
     "ee-first": {
       "version": "1.1.1",
@@ -576,60 +599,59 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "emissary": {
-      "version": "https://registry.npmjs.org/emissary/-/emissary-1.3.3.tgz",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/emissary/-/emissary-1.3.3.tgz",
       "integrity": "sha1-phjZLWgrIy0xER3DYlpd9mF5lgY=",
       "requires": {
-        "es6-weak-map": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
-        "mixto": "https://registry.npmjs.org/mixto/-/mixto-1.0.0.tgz",
-        "property-accessors": "https://registry.npmjs.org/property-accessors/-/property-accessors-1.1.3.tgz",
-        "underscore-plus": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.6.6.tgz"
+        "es6-weak-map": "0.1.4",
+        "mixto": "1.0.0",
+        "property-accessors": "1.1.3",
+        "underscore-plus": "1.6.8"
       }
     },
     "encodeurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "engine.io": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.1.4.tgz",
-      "integrity": "sha1-PQIRtwpVLOhB/8fahiezAamkFi4=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
+      "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
       "requires": {
-        "accepts": "1.3.3",
+        "accepts": "1.3.5",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
-        "debug": "2.6.9",
-        "engine.io-parser": "2.1.1",
-        "uws": "0.14.5",
-        "ws": "3.3.2"
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
+        "ws": "3.3.3"
       },
       "dependencies": {
-        "accepts": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-          "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
-            "mime-types": "2.1.17",
-            "negotiator": "0.6.1"
+            "ms": "2.0.0"
           }
         }
       }
     },
     "engine.io-client": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.4.tgz",
-      "integrity": "sha1-T88TcLRxY70s6b4nM5ckMDUNTqE=",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+      "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "2.6.9",
-        "engine.io-parser": "2.1.1",
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "3.3.2",
-        "xmlhttprequest-ssl": "1.5.4",
+        "ws": "3.3.3",
+        "xmlhttprequest-ssl": "1.5.5",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -637,88 +659,96 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
           "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
     "engine.io-parser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.1.tgz",
-      "integrity": "sha1-4Ps/DgRi9/WLt3waUun1p+JuRmg=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
+      "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
       "requires": {
         "after": "0.8.2",
-        "arraybuffer.slice": "0.0.6",
+        "arraybuffer.slice": "0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.4",
-        "has-binary2": "1.0.2"
-      }
-    },
-    "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "requires": {
-        "is-arrayish": "0.2.1"
-      },
-      "dependencies": {
-        "is-arrayish": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-        }
+        "has-binary2": "1.0.3"
       }
     },
     "es5-ext": {
-      "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
-      "integrity": "sha1-gYTD5wWoIJSMLb4EOEk3mx29DEU=",
+      "version": "0.10.45",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
+      "integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
       "requires": {
-        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "next-tick": "1.0.0"
       },
       "dependencies": {
-        "es6-iterator": {
-          "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-          "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
+        "d": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "requires": {
-            "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-            "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
-            "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
+            "es5-ext": "0.10.45"
+          }
+        },
+        "es6-iterator": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+          "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.45",
+            "es6-symbol": "3.1.1"
           }
         },
         "es6-symbol": {
-          "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
-          "integrity": "sha1-HpKIeMb15jVBYltLtN9K8H0VQhk=",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
           "requires": {
-            "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-            "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
+            "d": "1.0.0",
+            "es5-ext": "0.10.45"
           }
         }
       }
     },
     "es6-iterator": {
-      "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
       "integrity": "sha1-1vWLjE/EE8JJtLqhl2j45NfIlE4=",
       "requires": {
-        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
-        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+        "d": "0.1.1",
+        "es5-ext": "0.10.45",
+        "es6-symbol": "2.0.1"
       }
     },
     "es6-symbol": {
-      "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
       "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M=",
       "requires": {
-        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
+        "d": "0.1.1",
+        "es5-ext": "0.10.45"
       }
     },
     "es6-weak-map": {
-      "version": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
       "integrity": "sha1-cGzvnpmqI2undmwjnIueKG6n0ig=",
       "requires": {
-        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
-        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+        "d": "0.1.1",
+        "es5-ext": "0.10.45",
+        "es6-iterator": "0.1.3",
+        "es6-symbol": "2.0.1"
       }
     },
     "escape-html": {
@@ -751,49 +781,107 @@
       }
     },
     "express": {
-      "version": "4.15.5",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.15.5.tgz",
-      "integrity": "sha1-ZwI1ypWYiQpa6BcLg9tyK4Qu2Sc=",
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+      "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "requires": {
-        "accepts": "1.3.4",
+        "accepts": "1.3.5",
         "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
         "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.1",
-        "encodeurl": "1.0.1",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
-        "finalhandler": "1.0.6",
+        "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "1.1.2",
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "1.1.5",
-        "qs": "6.5.0",
+        "proxy-addr": "2.0.3",
+        "qs": "6.5.1",
         "range-parser": "1.2.0",
-        "send": "0.15.6",
-        "serve-static": "1.12.6",
-        "setprototypeof": "1.0.3",
-        "statuses": "1.3.1",
-        "type-is": "1.6.15",
-        "utils-merge": "1.0.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.4.0",
+        "type-is": "1.6.16",
+        "utils-merge": "1.0.1",
         "vary": "1.1.2"
       },
       "dependencies": {
+        "body-parser": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+          "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "1.0.4",
+            "debug": "2.6.9",
+            "depd": "1.1.2",
+            "http-errors": "1.6.3",
+            "iconv-lite": "0.4.19",
+            "on-finished": "2.3.0",
+            "qs": "6.5.1",
+            "raw-body": "2.3.2",
+            "type-is": "1.6.16"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+        },
         "qs": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-          "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg=="
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+        },
+        "raw-body": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+          "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+          "requires": {
+            "bytes": "3.0.0",
+            "http-errors": "1.6.2",
+            "iconv-lite": "0.4.19",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "depd": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+            },
+            "http-errors": {
+              "version": "1.6.2",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+              "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+              "requires": {
+                "depd": "1.1.1",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.0.3",
+                "statuses": "1.4.0"
+              }
+            },
+            "setprototypeof": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+              "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+            }
+          }
         },
         "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
         }
       }
     },
@@ -806,18 +894,11 @@
         "cookie-signature": "1.0.6",
         "crc": "3.4.4",
         "debug": "2.6.9",
-        "depd": "1.1.1",
+        "depd": "1.1.2",
         "on-headers": "1.0.1",
         "parseurl": "1.3.2",
         "uid-safe": "2.1.5",
         "utils-merge": "1.0.1"
-      },
-      "dependencies": {
-        "utils-merge": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
-        }
       }
     },
     "extend": {
@@ -831,8 +912,8 @@
       "integrity": "sha1-WrvtyYwNUgLjJ4cn+Rktfghsa+E=",
       "requires": {
         "eachr": "3.2.0",
-        "editions": "1.3.3",
-        "typechecker": "4.4.1"
+        "editions": "1.3.4",
+        "typechecker": "4.5.0"
       }
     },
     "extsprintf": {
@@ -846,9 +927,9 @@
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
     "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -856,23 +937,23 @@
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "finalhandler": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
-      "integrity": "sha1-AHrqM9Gk0+QgF/YkhIrVjSEvgU8=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
-        "statuses": "1.3.1",
+        "statuses": "1.4.0",
         "unpipe": "1.0.0"
       },
       "dependencies": {
         "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
         }
       }
     },
@@ -899,11 +980,6 @@
         "mime": "1.2.11"
       },
       "dependencies": {
-        "async": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
-        },
         "mime": {
           "version": "1.2.11",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
@@ -932,7 +1008,8 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fuzzaldrin": {
-      "version": "https://registry.npmjs.org/fuzzaldrin/-/fuzzaldrin-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fuzzaldrin/-/fuzzaldrin-2.1.0.tgz",
       "integrity": "sha1-kCBMPi/appQbso0WZF1BgGOpDps="
     },
     "gauge": {
@@ -948,7 +1025,7 @@
         "signal-exit": "3.0.2",
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "wide-align": "1.1.3"
       }
     },
     "get-caller-file": {
@@ -962,10 +1039,11 @@
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "getmac": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/getmac/-/getmac-1.2.1.tgz",
-      "integrity": "sha1-DQlf0GJ4UAQ+rB3PoLEgu9wUJtE=",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/getmac/-/getmac-1.4.3.tgz",
+      "integrity": "sha512-bOZafIX+19cCS5KUjHtlJPZW+4joMa5tISIk5CugjmlZE0zZtjwB59wm56JPXVy5ELivw7g4Z9TEI0EDa2CSwQ==",
       "requires": {
+        "editions": "1.3.4",
         "extract-opts": "3.3.1"
       }
     },
@@ -996,10 +1074,11 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "grim": {
-      "version": "https://registry.npmjs.org/grim/-/grim-1.5.0.tgz",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/grim/-/grim-1.5.0.tgz",
       "integrity": "sha1-sysI71Z88YUvgXWe2caLDXE5ajI=",
       "requires": {
-        "emissary": "https://registry.npmjs.org/emissary/-/emissary-1.3.3.tgz"
+        "emissary": "1.3.3"
       }
     },
     "har-schema": {
@@ -1012,14 +1091,14 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.1",
+        "ajv": "5.5.2",
         "har-schema": "2.0.0"
       }
     },
     "has-binary2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.2.tgz",
-      "integrity": "sha1-6D26SfC5vk0CbSc2U1DZ8D9Uvpg=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
+      "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
       "requires": {
         "isarray": "2.0.1"
       },
@@ -1050,22 +1129,6 @@
         "signals": "1.0.0"
       }
     },
-    "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.1.0"
-      }
-    },
-    "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
-    },
     "hogan.js": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
@@ -1083,19 +1146,19 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
     },
     "http-errors": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
-        "depd": "1.1.1",
+        "depd": "1.1.2",
         "inherits": "2.0.3",
-        "setprototypeof": "1.0.3",
-        "statuses": "1.4.0"
+        "setprototypeof": "1.1.0",
+        "statuses": "1.5.0"
       }
     },
     "http-signature": {
@@ -1105,18 +1168,21 @@
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "sshpk": "1.14.2"
       }
     },
     "iconv-lite": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
     },
     "ignore": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
     },
     "indexof": {
       "version": "0.0.1",
@@ -1148,14 +1214,19 @@
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "ipaddr.js": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
-      "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+      "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
     },
     "is-arrayish": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.1.tgz",
-      "integrity": "sha1-wt/DhquqDD4zxI2z/ocFnmkGXv0="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -1199,8 +1270,14 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jquery": {
-      "version": "https://registry.npmjs.org/jquery/-/jquery-2.1.4.tgz",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.4.tgz",
       "integrity": "sha1-IoveaYoMYUMdwmMKahVPFYkNIxc="
+    },
+    "jquery-ui-bundle": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/jquery-ui-bundle/-/jquery-ui-bundle-1.12.1.tgz",
+      "integrity": "sha1-1r4uTDd0lOI3ixyuKSCpHRGC2MQ="
     },
     "jsbn": {
       "version": "0.1.1",
@@ -1240,9 +1317,9 @@
       "integrity": "sha1-e/hmDPFVcf5887ScIi5HFuFgWgw="
     },
     "keen.io": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/keen.io/-/keen.io-0.1.3.tgz",
-      "integrity": "sha1-UFb1yYmrFMz2L8IO11mBFa59CeM=",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/keen.io/-/keen.io-0.1.5.tgz",
+      "integrity": "sha512-THuLqGgrsqRiszyq7Mkasf4uKCtpIXjoptQJZQcvQ6WutSjf17ndJ/eHZCi7IbvulNq5NwJWBH1earF0duIzDw==",
       "requires": {
         "superagent": "0.21.0",
         "underscore": "1.5.2"
@@ -1289,9 +1366,9 @@
       }
     },
     "knockout": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/knockout/-/knockout-3.4.2.tgz",
-      "integrity": "sha1-6HlY3netHpNvfOZFuri118RW2Tc="
+      "version": "3.5.0-rc",
+      "resolved": "https://registry.npmjs.org/knockout/-/knockout-3.5.0-rc.tgz",
+      "integrity": "sha512-eROh551BD9dDQ2ItCF60IPcZZXP46WiEcFCU6pVlekeQ6mv3L+in4u8BIIUDp1h0OtL7IXLwvwEY8HkG/BPtrQ=="
     },
     "lcid": {
       "version": "1.0.0",
@@ -1299,17 +1376,6 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
         "invert-kv": "1.0.0"
-      }
-    },
-    "load-json-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "strip-bom": "3.0.0"
       }
     },
     "locate-path": {
@@ -1321,24 +1387,34 @@
         "path-exists": "3.0.0"
       }
     },
+    "locks": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/locks/-/locks-0.2.2.tgz",
+      "integrity": "sha1-JZkz0TJ8uvD9NmL4//3jaAnYTO0="
+    },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
       }
     },
-    "lsmod": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lsmod/-/lsmod-1.0.0.tgz",
-      "integrity": "sha1-mgD3bco26yP6BTUK/htYXUKZ5ks="
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "1.1.6"
+      }
     },
     "media-typer": {
       "version": "0.3.0",
@@ -1350,7 +1426,7 @@
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "memorystore": {
@@ -1359,7 +1435,7 @@
       "integrity": "sha1-H7X7Xwsu3xrdGEkX6RjwlKn/NGU=",
       "requires": {
         "debug": "3.1.0",
-        "lru-cache": "4.1.1"
+        "lru-cache": "4.1.3"
       },
       "dependencies": {
         "debug": {
@@ -1383,34 +1459,34 @@
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "mime": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
     },
     "mime-db": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
     },
     "mime-types": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "1.33.0"
       }
     },
     "mimic-fn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -1419,7 +1495,8 @@
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mixto": {
-      "version": "https://registry.npmjs.org/mixto/-/mixto-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mixto/-/mixto-1.0.0.tgz",
       "integrity": "sha1-wyDvYbUvKJj1IuF9i7xtUG2EJbY="
     },
     "mkdirp": {
@@ -1431,9 +1508,9 @@
       }
     },
     "moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
     },
     "ms": {
       "version": "2.0.0",
@@ -1445,13 +1522,18 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
     "node-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.1.1.tgz",
-      "integrity": "sha1-CFJGRe5AOd7cPcwd18a5eeBhnkQ=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.0.tgz",
+      "integrity": "sha512-obRu6/f7S024ysheAjoYFEEBqqDWv4LOMNJEuO8vMeEw2AT4z+NCzO4hlc2lhI4vATzbCQv6kke9FVdx0RbCOw==",
       "requires": {
         "clone": "2.1.1",
-        "lodash": "4.17.4"
+        "lodash": "4.17.10"
       }
     },
     "nopt": {
@@ -1467,50 +1549,63 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
-        "hosted-git-info": "2.5.0",
+        "hosted-git-info": "2.6.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
-        "validate-npm-package-license": "3.0.1"
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.3"
       }
     },
     "npm": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-5.4.2.tgz",
-      "integrity": "sha512-F6LLCAHriKyKQ9Ff03UKCjkXZoRBp281I42K42+VeHfjAXZ3TJdg3RccinzoCFV1kDxCedVm7AstIpb1Uf5UkQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.1.0.tgz",
+      "integrity": "sha512-e38cCtJ0lEjLXXpc4twEfj8Xw5hDLolc2Py87ueWnUhJfZ8GA/5RVIeD+XbSr1+aVRGsRsdtLdzUNO63PvQJ1w==",
       "requires": {
-        "JSONStream": "1.3.1",
-        "abbrev": "1.1.0",
+        "JSONStream": "1.3.2",
+        "abbrev": "1.1.1",
         "ansi-regex": "3.0.0",
         "ansicolors": "0.3.2",
         "ansistyles": "0.1.3",
-        "aproba": "1.1.2",
+        "aproba": "1.2.0",
         "archy": "1.0.0",
-        "bluebird": "3.5.0",
-        "cacache": "9.2.9",
+        "bin-links": "1.1.2",
+        "bluebird": "3.5.1",
+        "byte-size": "4.0.3",
+        "cacache": "11.0.2",
         "call-limit": "1.1.0",
         "chownr": "1.0.1",
+        "cli-columns": "3.1.2",
+        "cli-table2": "0.2.0",
         "cmd-shim": "2.0.2",
         "columnify": "1.5.4",
         "config-chain": "1.1.11",
         "debuglog": "1.0.1",
         "detect-indent": "5.0.0",
+        "detect-newline": "2.1.0",
         "dezalgo": "1.0.3",
         "editor": "1.0.0",
+        "figgy-pudding": "3.1.0",
+        "find-npm-prefix": "1.0.2",
         "fs-vacuum": "1.2.10",
         "fs-write-stream-atomic": "1.0.10",
+        "gentle-fs": "2.0.1",
         "glob": "7.1.2",
         "graceful-fs": "4.1.11",
         "has-unicode": "2.0.1",
-        "hosted-git-info": "2.5.0",
-        "iferr": "0.1.5",
+        "hosted-git-info": "2.6.0",
+        "iferr": "1.0.0",
         "imurmurhash": "0.1.4",
         "inflight": "1.0.6",
         "inherits": "2.0.3",
-        "ini": "1.3.4",
-        "init-package-json": "1.10.1",
+        "ini": "1.3.5",
+        "init-package-json": "1.10.3",
+        "is-cidr": "2.0.5",
+        "json-parse-better-errors": "1.0.2",
         "lazy-property": "1.0.0",
-        "libnpx": "9.6.0",
-        "lockfile": "1.0.3",
+        "libcipm": "1.6.2",
+        "libnpmhook": "4.0.1",
+        "libnpx": "10.2.0",
+        "lock-verify": "2.0.2",
+        "lockfile": "1.0.4",
         "lodash._baseindexof": "3.1.0",
         "lodash._baseuniq": "4.6.0",
         "lodash._bindcallback": "3.0.1",
@@ -1522,64 +1617,72 @@
         "lodash.union": "4.6.0",
         "lodash.uniq": "4.5.0",
         "lodash.without": "4.4.0",
-        "lru-cache": "4.1.1",
-        "meant": "1.0.0",
-        "mississippi": "1.3.0",
+        "lru-cache": "4.1.3",
+        "meant": "1.0.1",
+        "mississippi": "3.0.0",
         "mkdirp": "0.5.1",
         "move-concurrently": "1.0.1",
         "node-gyp": "3.6.2",
         "nopt": "4.0.1",
         "normalize-package-data": "2.4.0",
+        "npm-audit-report": "1.2.1",
         "npm-cache-filename": "1.0.2",
         "npm-install-checks": "3.0.0",
-        "npm-lifecycle": "1.0.2",
-        "npm-package-arg": "5.1.2",
-        "npm-packlist": "1.1.8",
-        "npm-registry-client": "8.4.0",
+        "npm-lifecycle": "2.0.3",
+        "npm-package-arg": "6.1.0",
+        "npm-packlist": "1.1.10",
+        "npm-pick-manifest": "2.1.0",
+        "npm-profile": "3.0.1",
+        "npm-registry-client": "8.5.1",
+        "npm-registry-fetch": "1.1.0",
         "npm-user-validate": "1.0.0",
         "npmlog": "4.1.2",
         "once": "1.4.0",
         "opener": "1.4.3",
-        "osenv": "0.1.4",
-        "pacote": "6.0.2",
+        "osenv": "0.1.5",
+        "pacote": "8.1.5",
         "path-is-inside": "1.0.2",
         "promise-inflight": "1.0.1",
+        "qrcode-terminal": "0.12.0",
+        "query-string": "6.1.0",
+        "qw": "1.0.1",
         "read": "1.0.7",
         "read-cmd-shim": "1.0.1",
         "read-installed": "4.0.3",
-        "read-package-json": "2.0.12",
-        "read-package-tree": "5.1.6",
-        "readable-stream": "2.3.3",
+        "read-package-json": "2.0.13",
+        "read-package-tree": "5.2.1",
+        "readable-stream": "2.3.6",
         "readdir-scoped-modules": "1.0.2",
-        "request": "2.81.0",
-        "retry": "0.10.1",
-        "rimraf": "2.6.1",
-        "safe-buffer": "5.1.1",
-        "semver": "5.4.1",
+        "request": "2.86.0",
+        "retry": "0.12.0",
+        "rimraf": "2.6.2",
+        "safe-buffer": "5.1.2",
+        "semver": "5.5.0",
         "sha": "2.0.1",
         "slide": "1.1.6",
         "sorted-object": "2.0.1",
         "sorted-union-stream": "2.1.3",
-        "ssri": "4.1.6",
+        "ssri": "6.0.0",
         "strip-ansi": "4.0.0",
-        "tar": "4.0.1",
+        "tar": "4.4.1",
         "text-table": "0.2.0",
+        "tiny-relative-date": "1.3.0",
         "uid-number": "0.0.6",
         "umask": "1.1.0",
         "unique-filename": "1.1.0",
         "unpipe": "1.0.0",
-        "update-notifier": "2.2.0",
-        "uuid": "3.1.0",
-        "validate-npm-package-license": "3.0.1",
+        "update-notifier": "2.5.0",
+        "uuid": "3.2.1",
+        "validate-npm-package-license": "3.0.3",
         "validate-npm-package-name": "3.0.0",
         "which": "1.3.0",
-        "worker-farm": "1.5.0",
+        "worker-farm": "1.6.0",
         "wrappy": "1.0.2",
-        "write-file-atomic": "2.1.0"
+        "write-file-atomic": "2.3.0"
       },
       "dependencies": {
         "JSONStream": {
-          "version": "1.3.1",
+          "version": "1.3.2",
           "bundled": true,
           "requires": {
             "jsonparse": "1.3.1",
@@ -1597,7 +1700,7 @@
           }
         },
         "abbrev": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "bundled": true
         },
         "ansi-regex": {
@@ -1613,56 +1716,54 @@
           "bundled": true
         },
         "aproba": {
-          "version": "1.1.2",
+          "version": "1.2.0",
           "bundled": true
         },
         "archy": {
           "version": "1.0.0",
           "bundled": true
         },
+        "bin-links": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "bluebird": "3.5.1",
+            "cmd-shim": "2.0.2",
+            "gentle-fs": "2.0.1",
+            "graceful-fs": "4.1.11",
+            "write-file-atomic": "2.3.0"
+          }
+        },
         "bluebird": {
-          "version": "3.5.0",
+          "version": "3.5.1",
+          "bundled": true
+        },
+        "byte-size": {
+          "version": "4.0.3",
           "bundled": true
         },
         "cacache": {
-          "version": "9.2.9",
+          "version": "11.0.2",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.0",
+            "bluebird": "3.5.1",
             "chownr": "1.0.1",
+            "figgy-pudding": "3.1.0",
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
-            "lru-cache": "4.1.1",
-            "mississippi": "1.3.0",
+            "lru-cache": "4.1.3",
+            "mississippi": "3.0.0",
             "mkdirp": "0.5.1",
             "move-concurrently": "1.0.1",
             "promise-inflight": "1.0.1",
-            "rimraf": "2.6.1",
-            "ssri": "4.1.6",
+            "rimraf": "2.6.2",
+            "ssri": "6.0.0",
             "unique-filename": "1.1.0",
-            "y18n": "3.2.1"
+            "y18n": "4.0.0"
           },
           "dependencies": {
-            "lru-cache": {
-              "version": "4.1.1",
-              "bundled": true,
-              "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
-              },
-              "dependencies": {
-                "pseudomap": {
-                  "version": "1.0.2",
-                  "bundled": true
-                },
-                "yallist": {
-                  "version": "2.1.2",
-                  "bundled": true
-                }
-              }
-            },
             "y18n": {
-              "version": "3.2.1",
+              "version": "4.0.0",
               "bundled": true
             }
           }
@@ -1674,6 +1775,111 @@
         "chownr": {
           "version": "1.0.1",
           "bundled": true
+        },
+        "cli-columns": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "string-width": "2.1.1",
+            "strip-ansi": "3.0.1"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
+              },
+              "dependencies": {
+                "is-fullwidth-code-point": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "strip-ansi": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "3.0.0"
+                  }
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "cli-table2": {
+          "version": "0.2.0",
+          "bundled": true,
+          "requires": {
+            "colors": "1.1.2",
+            "lodash": "3.10.1",
+            "string-width": "1.0.2"
+          },
+          "dependencies": {
+            "colors": {
+              "version": "1.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              },
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  },
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            }
+          }
         },
         "cmd-shim": {
           "version": "2.0.2",
@@ -1732,7 +1938,7 @@
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "ini": "1.3.4",
+            "ini": "1.3.5",
             "proto-list": "1.2.4"
           },
           "dependencies": {
@@ -1748,6 +1954,10 @@
         },
         "detect-indent": {
           "version": "5.0.0",
+          "bundled": true
+        },
+        "detect-newline": {
+          "version": "2.1.0",
           "bundled": true
         },
         "dezalgo": {
@@ -1768,13 +1978,21 @@
           "version": "1.0.0",
           "bundled": true
         },
+        "figgy-pudding": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "find-npm-prefix": {
+          "version": "1.0.2",
+          "bundled": true
+        },
         "fs-vacuum": {
           "version": "1.2.10",
           "bundled": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "path-is-inside": "1.0.2",
-            "rimraf": "2.6.1"
+            "rimraf": "2.6.2"
           }
         },
         "fs-write-stream-atomic": {
@@ -1784,7 +2002,33 @@
             "graceful-fs": "4.1.11",
             "iferr": "0.1.5",
             "imurmurhash": "0.1.4",
-            "readable-stream": "2.3.3"
+            "readable-stream": "2.3.6"
+          },
+          "dependencies": {
+            "iferr": {
+              "version": "0.1.5",
+              "bundled": true
+            }
+          }
+        },
+        "gentle-fs": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "fs-vacuum": "1.2.10",
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "mkdirp": "0.5.1",
+            "path-is-inside": "1.0.2",
+            "read-cmd-shim": "1.0.1",
+            "slide": "1.1.6"
+          },
+          "dependencies": {
+            "iferr": {
+              "version": "0.1.5",
+              "bundled": true
+            }
           }
         },
         "glob": {
@@ -1845,11 +2089,11 @@
           "bundled": true
         },
         "hosted-git-info": {
-          "version": "2.5.0",
+          "version": "2.6.0",
           "bundled": true
         },
         "iferr": {
-          "version": "0.1.5",
+          "version": "1.0.0",
           "bundled": true
         },
         "imurmurhash": {
@@ -1869,20 +2113,20 @@
           "bundled": true
         },
         "ini": {
-          "version": "1.3.4",
+          "version": "1.3.5",
           "bundled": true
         },
         "init-package-json": {
-          "version": "1.10.1",
+          "version": "1.10.3",
           "bundled": true,
           "requires": {
             "glob": "7.1.2",
-            "npm-package-arg": "5.1.2",
+            "npm-package-arg": "6.1.0",
             "promzard": "0.3.0",
             "read": "1.0.7",
-            "read-package-json": "2.0.12",
-            "semver": "5.4.1",
-            "validate-npm-package-license": "3.0.1",
+            "read-package-json": "2.0.13",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.3",
             "validate-npm-package-name": "3.0.0"
           },
           "dependencies": {
@@ -1895,111 +2139,1046 @@
             }
           }
         },
+        "is-cidr": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "cidr-regex": "2.0.8"
+          },
+          "dependencies": {
+            "cidr-regex": {
+              "version": "2.0.8",
+              "bundled": true,
+              "requires": {
+                "ip-regex": "2.1.0"
+              },
+              "dependencies": {
+                "ip-regex": {
+                  "version": "2.1.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true
+        },
         "lazy-property": {
           "version": "1.0.0",
           "bundled": true
         },
-        "libnpx": {
-          "version": "9.6.0",
+        "libcipm": {
+          "version": "1.6.2",
           "bundled": true,
           "requires": {
-            "dotenv": "4.0.0",
-            "npm-package-arg": "5.1.2",
-            "rimraf": "2.6.1",
-            "safe-buffer": "5.1.1",
-            "update-notifier": "2.2.0",
-            "which": "1.3.0",
-            "y18n": "3.2.1",
-            "yargs": "8.0.2"
+            "bin-links": "1.1.2",
+            "bluebird": "3.5.1",
+            "find-npm-prefix": "1.0.2",
+            "graceful-fs": "4.1.11",
+            "lock-verify": "2.0.2",
+            "npm-lifecycle": "2.0.3",
+            "npm-logical-tree": "1.2.1",
+            "npm-package-arg": "6.1.0",
+            "pacote": "7.6.1",
+            "protoduck": "5.0.0",
+            "read-package-json": "2.0.13",
+            "rimraf": "2.6.2",
+            "worker-farm": "1.6.0"
           },
           "dependencies": {
-            "dotenv": {
-              "version": "4.0.0",
+            "npm-logical-tree": {
+              "version": "1.2.1",
               "bundled": true
             },
-            "y18n": {
-              "version": "3.2.1",
-              "bundled": true
-            },
-            "yargs": {
-              "version": "8.0.2",
+            "pacote": {
+              "version": "7.6.1",
               "bundled": true,
               "requires": {
-                "camelcase": "4.1.0",
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "get-caller-file": "1.0.2",
-                "os-locale": "2.1.0",
-                "read-pkg-up": "2.0.0",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "2.1.1",
-                "which-module": "2.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "7.0.0"
+                "bluebird": "3.5.1",
+                "cacache": "10.0.4",
+                "get-stream": "3.0.0",
+                "glob": "7.1.2",
+                "lru-cache": "4.1.3",
+                "make-fetch-happen": "2.6.0",
+                "minimatch": "3.0.4",
+                "mississippi": "3.0.0",
+                "mkdirp": "0.5.1",
+                "normalize-package-data": "2.4.0",
+                "npm-package-arg": "6.1.0",
+                "npm-packlist": "1.1.10",
+                "npm-pick-manifest": "2.1.0",
+                "osenv": "0.1.5",
+                "promise-inflight": "1.0.1",
+                "promise-retry": "1.1.1",
+                "protoduck": "5.0.0",
+                "rimraf": "2.6.2",
+                "safe-buffer": "5.1.2",
+                "semver": "5.5.0",
+                "ssri": "5.3.0",
+                "tar": "4.4.1",
+                "unique-filename": "1.1.0",
+                "which": "1.3.0"
               },
               "dependencies": {
-                "camelcase": {
-                  "version": "4.1.0",
-                  "bundled": true
-                },
-                "cliui": {
-                  "version": "3.2.0",
+                "cacache": {
+                  "version": "10.0.4",
                   "bundled": true,
                   "requires": {
-                    "string-width": "1.0.2",
-                    "strip-ansi": "3.0.1",
-                    "wrap-ansi": "2.1.0"
+                    "bluebird": "3.5.1",
+                    "chownr": "1.0.1",
+                    "glob": "7.1.2",
+                    "graceful-fs": "4.1.11",
+                    "lru-cache": "4.1.3",
+                    "mississippi": "2.0.0",
+                    "mkdirp": "0.5.1",
+                    "move-concurrently": "1.0.1",
+                    "promise-inflight": "1.0.1",
+                    "rimraf": "2.6.2",
+                    "ssri": "5.3.0",
+                    "unique-filename": "1.1.0",
+                    "y18n": "4.0.0"
                   },
                   "dependencies": {
-                    "string-width": {
-                      "version": "1.0.2",
+                    "mississippi": {
+                      "version": "2.0.0",
                       "bundled": true,
                       "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "concat-stream": "1.6.2",
+                        "duplexify": "3.5.4",
+                        "end-of-stream": "1.4.1",
+                        "flush-write-stream": "1.0.3",
+                        "from2": "2.3.0",
+                        "parallel-transform": "1.1.0",
+                        "pump": "2.0.1",
+                        "pumpify": "1.4.0",
+                        "stream-each": "1.2.2",
+                        "through2": "2.0.3"
                       },
                       "dependencies": {
-                        "code-point-at": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "is-fullwidth-code-point": {
-                          "version": "1.0.0",
+                        "concat-stream": {
+                          "version": "1.6.2",
                           "bundled": true,
                           "requires": {
-                            "number-is-nan": "1.0.1"
+                            "buffer-from": "1.0.0",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "typedarray": "0.0.6"
                           },
                           "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.1",
+                            "buffer-from": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            },
+                            "typedarray": {
+                              "version": "0.0.6",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "duplexify": {
+                          "version": "3.5.4",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "end-of-stream": {
+                          "version": "1.4.1",
+                          "bundled": true,
+                          "requires": {
+                            "once": "1.4.0"
+                          }
+                        },
+                        "flush-write-stream": {
+                          "version": "1.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "from2": {
+                          "version": "2.3.0",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "parallel-transform": {
+                          "version": "1.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "cyclist": "0.2.2",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          },
+                          "dependencies": {
+                            "cyclist": {
+                              "version": "0.2.2",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "pump": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
+                          }
+                        },
+                        "pumpify": {
+                          "version": "1.4.0",
+                          "bundled": true,
+                          "requires": {
+                            "duplexify": "3.5.4",
+                            "inherits": "2.0.3",
+                            "pump": "2.0.1"
+                          }
+                        },
+                        "stream-each": {
+                          "version": "1.2.2",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "through2": {
+                          "version": "2.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "readable-stream": "2.3.6",
+                            "xtend": "4.0.1"
+                          },
+                          "dependencies": {
+                            "xtend": {
+                              "version": "4.0.1",
                               "bundled": true
                             }
                           }
                         }
                       }
                     },
-                    "strip-ansi": {
+                    "y18n": {
+                      "version": "4.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "get-stream": {
+                  "version": "3.0.0",
+                  "bundled": true
+                },
+                "make-fetch-happen": {
+                  "version": "2.6.0",
+                  "bundled": true,
+                  "requires": {
+                    "agentkeepalive": "3.4.1",
+                    "cacache": "10.0.4",
+                    "http-cache-semantics": "3.8.1",
+                    "http-proxy-agent": "2.1.0",
+                    "https-proxy-agent": "2.2.1",
+                    "lru-cache": "4.1.3",
+                    "mississippi": "1.3.1",
+                    "node-fetch-npm": "2.0.2",
+                    "promise-retry": "1.1.1",
+                    "socks-proxy-agent": "3.0.1",
+                    "ssri": "5.3.0"
+                  },
+                  "dependencies": {
+                    "agentkeepalive": {
+                      "version": "3.4.1",
+                      "bundled": true,
+                      "requires": {
+                        "humanize-ms": "1.2.1"
+                      },
+                      "dependencies": {
+                        "humanize-ms": {
+                          "version": "1.2.1",
+                          "bundled": true,
+                          "requires": {
+                            "ms": "2.1.1"
+                          },
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.1.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "http-cache-semantics": {
+                      "version": "3.8.1",
+                      "bundled": true
+                    },
+                    "http-proxy-agent": {
+                      "version": "2.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "agent-base": "4.2.0",
+                        "debug": "3.1.0"
+                      },
+                      "dependencies": {
+                        "agent-base": {
+                          "version": "4.2.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promisify": "5.0.0"
+                          },
+                          "dependencies": {
+                            "es6-promisify": {
+                              "version": "5.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "es6-promise": "4.2.4"
+                              },
+                              "dependencies": {
+                                "es6-promise": {
+                                  "version": "4.2.4",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "debug": {
+                          "version": "3.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "ms": "2.0.0"
+                          },
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.0.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "https-proxy-agent": {
+                      "version": "2.2.1",
+                      "bundled": true,
+                      "requires": {
+                        "agent-base": "4.2.0",
+                        "debug": "3.1.0"
+                      },
+                      "dependencies": {
+                        "agent-base": {
+                          "version": "4.2.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promisify": "5.0.0"
+                          },
+                          "dependencies": {
+                            "es6-promisify": {
+                              "version": "5.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "es6-promise": "4.2.4"
+                              },
+                              "dependencies": {
+                                "es6-promise": {
+                                  "version": "4.2.4",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "debug": {
+                          "version": "3.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "ms": "2.0.0"
+                          },
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.0.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "mississippi": {
+                      "version": "1.3.1",
+                      "bundled": true,
+                      "requires": {
+                        "concat-stream": "1.6.2",
+                        "duplexify": "3.5.4",
+                        "end-of-stream": "1.4.1",
+                        "flush-write-stream": "1.0.3",
+                        "from2": "2.3.0",
+                        "parallel-transform": "1.1.0",
+                        "pump": "1.0.3",
+                        "pumpify": "1.4.0",
+                        "stream-each": "1.2.2",
+                        "through2": "2.0.3"
+                      },
+                      "dependencies": {
+                        "concat-stream": {
+                          "version": "1.6.2",
+                          "bundled": true,
+                          "requires": {
+                            "buffer-from": "1.0.0",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "typedarray": "0.0.6"
+                          },
+                          "dependencies": {
+                            "buffer-from": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            },
+                            "typedarray": {
+                              "version": "0.0.6",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "duplexify": {
+                          "version": "3.5.4",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "end-of-stream": {
+                          "version": "1.4.1",
+                          "bundled": true,
+                          "requires": {
+                            "once": "1.4.0"
+                          }
+                        },
+                        "flush-write-stream": {
+                          "version": "1.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "from2": {
+                          "version": "2.3.0",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "parallel-transform": {
+                          "version": "1.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "cyclist": "0.2.2",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          },
+                          "dependencies": {
+                            "cyclist": {
+                              "version": "0.2.2",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "pump": {
+                          "version": "1.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
+                          }
+                        },
+                        "pumpify": {
+                          "version": "1.4.0",
+                          "bundled": true,
+                          "requires": {
+                            "duplexify": "3.5.4",
+                            "inherits": "2.0.3",
+                            "pump": "2.0.1"
+                          },
+                          "dependencies": {
+                            "pump": {
+                              "version": "2.0.1",
+                              "bundled": true,
+                              "requires": {
+                                "end-of-stream": "1.4.1",
+                                "once": "1.4.0"
+                              }
+                            }
+                          }
+                        },
+                        "stream-each": {
+                          "version": "1.2.2",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "through2": {
+                          "version": "2.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "readable-stream": "2.3.6",
+                            "xtend": "4.0.1"
+                          },
+                          "dependencies": {
+                            "xtend": {
+                              "version": "4.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "node-fetch-npm": {
+                      "version": "2.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "encoding": "0.1.12",
+                        "json-parse-better-errors": "1.0.2",
+                        "safe-buffer": "5.1.2"
+                      },
+                      "dependencies": {
+                        "encoding": {
+                          "version": "0.1.12",
+                          "bundled": true,
+                          "requires": {
+                            "iconv-lite": "0.4.21"
+                          },
+                          "dependencies": {
+                            "iconv-lite": {
+                              "version": "0.4.21",
+                              "bundled": true,
+                              "requires": {
+                                "safer-buffer": "2.1.2"
+                              },
+                              "dependencies": {
+                                "safer-buffer": {
+                                  "version": "2.1.2",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "socks-proxy-agent": {
                       "version": "3.0.1",
                       "bundled": true,
                       "requires": {
-                        "ansi-regex": "2.1.1"
+                        "agent-base": "4.2.0",
+                        "socks": "1.1.10"
                       },
                       "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.1.1",
+                        "agent-base": {
+                          "version": "4.2.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promisify": "5.0.0"
+                          },
+                          "dependencies": {
+                            "es6-promisify": {
+                              "version": "5.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "es6-promise": "4.2.4"
+                              },
+                              "dependencies": {
+                                "es6-promise": {
+                                  "version": "4.2.4",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "socks": {
+                          "version": "1.1.10",
+                          "bundled": true,
+                          "requires": {
+                            "ip": "1.1.5",
+                            "smart-buffer": "1.1.15"
+                          },
+                          "dependencies": {
+                            "ip": {
+                              "version": "1.1.5",
+                              "bundled": true
+                            },
+                            "smart-buffer": {
+                              "version": "1.1.15",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "brace-expansion": "1.1.11"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.11",
+                      "bundled": true,
+                      "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "promise-retry": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "err-code": "1.1.2",
+                    "retry": "0.10.1"
+                  },
+                  "dependencies": {
+                    "err-code": {
+                      "version": "1.1.2",
+                      "bundled": true
+                    },
+                    "retry": {
+                      "version": "0.10.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "ssri": {
+                  "version": "5.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "safe-buffer": "5.1.2"
+                  }
+                }
+              }
+            },
+            "protoduck": {
+              "version": "5.0.0",
+              "bundled": true,
+              "requires": {
+                "genfun": "4.0.1"
+              },
+              "dependencies": {
+                "genfun": {
+                  "version": "4.0.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "libnpmhook": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "figgy-pudding": "3.1.0",
+            "npm-registry-fetch": "3.1.1"
+          },
+          "dependencies": {
+            "npm-registry-fetch": {
+              "version": "3.1.1",
+              "bundled": true,
+              "requires": {
+                "bluebird": "3.5.1",
+                "figgy-pudding": "3.1.0",
+                "lru-cache": "4.1.3",
+                "make-fetch-happen": "4.0.1",
+                "npm-package-arg": "6.1.0"
+              },
+              "dependencies": {
+                "make-fetch-happen": {
+                  "version": "4.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "agentkeepalive": "3.4.1",
+                    "cacache": "11.0.2",
+                    "http-cache-semantics": "3.8.1",
+                    "http-proxy-agent": "2.1.0",
+                    "https-proxy-agent": "2.2.1",
+                    "lru-cache": "4.1.3",
+                    "mississippi": "3.0.0",
+                    "node-fetch-npm": "2.0.2",
+                    "promise-retry": "1.1.1",
+                    "socks-proxy-agent": "4.0.0",
+                    "ssri": "6.0.0"
+                  },
+                  "dependencies": {
+                    "agentkeepalive": {
+                      "version": "3.4.1",
+                      "bundled": true,
+                      "requires": {
+                        "humanize-ms": "1.2.1"
+                      },
+                      "dependencies": {
+                        "humanize-ms": {
+                          "version": "1.2.1",
+                          "bundled": true,
+                          "requires": {
+                            "ms": "2.1.1"
+                          },
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.1.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "http-cache-semantics": {
+                      "version": "3.8.1",
+                      "bundled": true
+                    },
+                    "http-proxy-agent": {
+                      "version": "2.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "agent-base": "4.2.0",
+                        "debug": "3.1.0"
+                      },
+                      "dependencies": {
+                        "agent-base": {
+                          "version": "4.2.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promisify": "5.0.0"
+                          },
+                          "dependencies": {
+                            "es6-promisify": {
+                              "version": "5.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "es6-promise": "4.2.4"
+                              },
+                              "dependencies": {
+                                "es6-promise": {
+                                  "version": "4.2.4",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "debug": {
+                          "version": "3.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "ms": "2.0.0"
+                          },
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.0.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "https-proxy-agent": {
+                      "version": "2.2.1",
+                      "bundled": true,
+                      "requires": {
+                        "agent-base": "4.2.0",
+                        "debug": "3.1.0"
+                      },
+                      "dependencies": {
+                        "agent-base": {
+                          "version": "4.2.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promisify": "5.0.0"
+                          },
+                          "dependencies": {
+                            "es6-promisify": {
+                              "version": "5.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "es6-promise": "4.2.4"
+                              },
+                              "dependencies": {
+                                "es6-promise": {
+                                  "version": "4.2.4",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "debug": {
+                          "version": "3.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "ms": "2.0.0"
+                          },
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.0.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "node-fetch-npm": {
+                      "version": "2.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "encoding": "0.1.12",
+                        "json-parse-better-errors": "1.0.2",
+                        "safe-buffer": "5.1.2"
+                      },
+                      "dependencies": {
+                        "encoding": {
+                          "version": "0.1.12",
+                          "bundled": true,
+                          "requires": {
+                            "iconv-lite": "0.4.21"
+                          },
+                          "dependencies": {
+                            "iconv-lite": {
+                              "version": "0.4.21",
+                              "bundled": true,
+                              "requires": {
+                                "safer-buffer": "2.1.2"
+                              },
+                              "dependencies": {
+                                "safer-buffer": {
+                                  "version": "2.1.2",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "promise-retry": {
+                      "version": "1.1.1",
+                      "bundled": true,
+                      "requires": {
+                        "err-code": "1.1.2",
+                        "retry": "0.10.1"
+                      },
+                      "dependencies": {
+                        "err-code": {
+                          "version": "1.1.2",
+                          "bundled": true
+                        },
+                        "retry": {
+                          "version": "0.10.1",
                           "bundled": true
                         }
                       }
                     },
+                    "socks-proxy-agent": {
+                      "version": "4.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "agent-base": "4.1.2",
+                        "socks": "2.1.6"
+                      },
+                      "dependencies": {
+                        "agent-base": {
+                          "version": "4.1.2",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promisify": "5.0.0"
+                          },
+                          "dependencies": {
+                            "es6-promisify": {
+                              "version": "5.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "es6-promise": "4.2.4"
+                              },
+                              "dependencies": {
+                                "es6-promise": {
+                                  "version": "4.2.4",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "socks": {
+                          "version": "2.1.6",
+                          "bundled": true,
+                          "requires": {
+                            "ip": "1.1.5",
+                            "smart-buffer": "4.0.1"
+                          },
+                          "dependencies": {
+                            "ip": {
+                              "version": "1.1.5",
+                              "bundled": true
+                            },
+                            "smart-buffer": {
+                              "version": "4.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "libnpx": {
+          "version": "10.2.0",
+          "bundled": true,
+          "requires": {
+            "dotenv": "5.0.1",
+            "npm-package-arg": "6.1.0",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.2",
+            "update-notifier": "2.5.0",
+            "which": "1.3.0",
+            "y18n": "4.0.0",
+            "yargs": "11.0.0"
+          },
+          "dependencies": {
+            "dotenv": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "y18n": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "yargs": {
+              "version": "11.0.0",
+              "bundled": true,
+              "requires": {
+                "cliui": "4.0.0",
+                "decamelize": "1.2.0",
+                "find-up": "2.1.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "2.1.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "9.0.2"
+              },
+              "dependencies": {
+                "cliui": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "2.1.1",
+                    "strip-ansi": "4.0.0",
+                    "wrap-ansi": "2.1.0"
+                  },
+                  "dependencies": {
                     "wrap-ansi": {
                       "version": "2.1.0",
                       "bundled": true,
                       "requires": {
                         "string-width": "1.0.2",
                         "strip-ansi": "3.0.1"
+                      },
+                      "dependencies": {
+                        "string-width": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "requires": {
+                            "code-point-at": "1.1.0",
+                            "is-fullwidth-code-point": "1.0.0",
+                            "strip-ansi": "3.0.1"
+                          },
+                          "dependencies": {
+                            "code-point-at": {
+                              "version": "1.1.0",
+                              "bundled": true
+                            },
+                            "is-fullwidth-code-point": {
+                              "version": "1.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "number-is-nan": "1.0.1"
+                              },
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.1",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "ansi-regex": "2.1.1"
+                          },
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "bundled": true
+                            }
+                          }
+                        }
                       }
                     }
                   }
@@ -2007,6 +3186,51 @@
                 "decamelize": {
                   "version": "1.2.0",
                   "bundled": true
+                },
+                "find-up": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "locate-path": "2.0.0"
+                  },
+                  "dependencies": {
+                    "locate-path": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "p-locate": "2.0.0",
+                        "path-exists": "3.0.0"
+                      },
+                      "dependencies": {
+                        "p-locate": {
+                          "version": "2.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "p-limit": "1.2.0"
+                          },
+                          "dependencies": {
+                            "p-limit": {
+                              "version": "1.2.0",
+                              "bundled": true,
+                              "requires": {
+                                "p-try": "1.0.0"
+                              },
+                              "dependencies": {
+                                "p-try": {
+                                  "version": "1.0.0",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "path-exists": {
+                          "version": "3.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
                 },
                 "get-caller-file": {
                   "version": "1.0.2",
@@ -2038,7 +3262,7 @@
                           "version": "5.1.0",
                           "bundled": true,
                           "requires": {
-                            "lru-cache": "4.1.1",
+                            "lru-cache": "4.1.3",
                             "shebang-command": "1.2.0",
                             "which": "1.3.0"
                           },
@@ -2110,124 +3334,12 @@
                       "version": "1.1.0",
                       "bundled": true,
                       "requires": {
-                        "mimic-fn": "1.1.0"
+                        "mimic-fn": "1.2.0"
                       },
                       "dependencies": {
                         "mimic-fn": {
-                          "version": "1.1.0",
+                          "version": "1.2.0",
                           "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "read-pkg-up": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "find-up": "2.1.0",
-                    "read-pkg": "2.0.0"
-                  },
-                  "dependencies": {
-                    "find-up": {
-                      "version": "2.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "locate-path": "2.0.0"
-                      },
-                      "dependencies": {
-                        "locate-path": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "p-locate": "2.0.0",
-                            "path-exists": "3.0.0"
-                          },
-                          "dependencies": {
-                            "p-locate": {
-                              "version": "2.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "p-limit": "1.1.0"
-                              },
-                              "dependencies": {
-                                "p-limit": {
-                                  "version": "1.1.0",
-                                  "bundled": true
-                                }
-                              }
-                            },
-                            "path-exists": {
-                              "version": "3.0.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "read-pkg": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "load-json-file": "2.0.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "2.0.0"
-                      },
-                      "dependencies": {
-                        "load-json-file": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "graceful-fs": "4.1.11",
-                            "parse-json": "2.2.0",
-                            "pify": "2.3.0",
-                            "strip-bom": "3.0.0"
-                          },
-                          "dependencies": {
-                            "parse-json": {
-                              "version": "2.2.0",
-                              "bundled": true,
-                              "requires": {
-                                "error-ex": "1.3.1"
-                              },
-                              "dependencies": {
-                                "error-ex": {
-                                  "version": "1.3.1",
-                                  "bundled": true,
-                                  "requires": {
-                                    "is-arrayish": "0.2.1"
-                                  },
-                                  "dependencies": {
-                                    "is-arrayish": {
-                                      "version": "0.2.1",
-                                      "bundled": true
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "pify": {
-                              "version": "2.3.0",
-                              "bundled": true
-                            },
-                            "strip-bom": {
-                              "version": "3.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "path-type": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "pify": "2.3.0"
-                          },
-                          "dependencies": {
-                            "pify": {
-                              "version": "2.3.0",
-                              "bundled": true
-                            }
-                          }
                         }
                       }
                     }
@@ -2263,20 +3375,47 @@
                   "version": "2.0.0",
                   "bundled": true
                 },
+                "y18n": {
+                  "version": "3.2.1",
+                  "bundled": true
+                },
                 "yargs-parser": {
-                  "version": "7.0.0",
+                  "version": "9.0.2",
                   "bundled": true,
                   "requires": {
                     "camelcase": "4.1.0"
+                  },
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "4.1.0",
+                      "bundled": true
+                    }
                   }
                 }
               }
             }
           }
         },
+        "lock-verify": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "npm-package-arg": "6.1.0",
+            "semver": "5.5.0"
+          }
+        },
         "lockfile": {
-          "version": "1.0.3",
-          "bundled": true
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "signal-exit": "3.0.2"
+          },
+          "dependencies": {
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
@@ -2340,7 +3479,7 @@
           "bundled": true
         },
         "lru-cache": {
-          "version": "4.1.1",
+          "version": "4.1.3",
           "bundled": true,
           "requires": {
             "pseudomap": "1.0.2",
@@ -2358,31 +3497,31 @@
           }
         },
         "meant": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "bundled": true
         },
         "mississippi": {
-          "version": "1.3.0",
+          "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "concat-stream": "1.6.0",
-            "duplexify": "3.5.0",
-            "end-of-stream": "1.4.0",
+            "concat-stream": "1.6.1",
+            "duplexify": "3.5.4",
+            "end-of-stream": "1.4.1",
             "flush-write-stream": "1.0.2",
             "from2": "2.3.0",
             "parallel-transform": "1.1.0",
-            "pump": "1.0.2",
-            "pumpify": "1.3.5",
-            "stream-each": "1.2.0",
+            "pump": "3.0.0",
+            "pumpify": "1.4.0",
+            "stream-each": "1.2.2",
             "through2": "2.0.3"
           },
           "dependencies": {
             "concat-stream": {
-              "version": "1.6.0",
+              "version": "1.6.1",
               "bundled": true,
               "requires": {
                 "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
+                "readable-stream": "2.3.6",
                 "typedarray": "0.0.6"
               },
               "dependencies": {
@@ -2393,31 +3532,15 @@
               }
             },
             "duplexify": {
-              "version": "3.5.0",
+              "version": "3.5.4",
               "bundled": true,
               "requires": {
-                "end-of-stream": "1.0.0",
+                "end-of-stream": "1.4.1",
                 "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
+                "readable-stream": "2.3.6",
                 "stream-shift": "1.0.0"
               },
               "dependencies": {
-                "end-of-stream": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "once": "1.3.3"
-                  },
-                  "dependencies": {
-                    "once": {
-                      "version": "1.3.3",
-                      "bundled": true,
-                      "requires": {
-                        "wrappy": "1.0.2"
-                      }
-                    }
-                  }
-                },
                 "stream-shift": {
                   "version": "1.0.0",
                   "bundled": true
@@ -2425,7 +3548,7 @@
               }
             },
             "end-of-stream": {
-              "version": "1.4.0",
+              "version": "1.4.1",
               "bundled": true,
               "requires": {
                 "once": "1.4.0"
@@ -2436,7 +3559,7 @@
               "bundled": true,
               "requires": {
                 "inherits": "2.0.3",
-                "readable-stream": "2.3.3"
+                "readable-stream": "2.3.6"
               }
             },
             "from2": {
@@ -2444,7 +3567,7 @@
               "bundled": true,
               "requires": {
                 "inherits": "2.0.3",
-                "readable-stream": "2.3.3"
+                "readable-stream": "2.3.6"
               }
             },
             "parallel-transform": {
@@ -2453,7 +3576,7 @@
               "requires": {
                 "cyclist": "0.2.2",
                 "inherits": "2.0.3",
-                "readable-stream": "2.3.3"
+                "readable-stream": "2.3.6"
               },
               "dependencies": {
                 "cyclist": {
@@ -2463,27 +3586,37 @@
               }
             },
             "pump": {
-              "version": "1.0.2",
+              "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "end-of-stream": "1.4.0",
+                "end-of-stream": "1.4.1",
                 "once": "1.4.0"
               }
             },
             "pumpify": {
-              "version": "1.3.5",
+              "version": "1.4.0",
               "bundled": true,
               "requires": {
-                "duplexify": "3.5.0",
+                "duplexify": "3.5.4",
                 "inherits": "2.0.3",
-                "pump": "1.0.2"
+                "pump": "2.0.1"
+              },
+              "dependencies": {
+                "pump": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "end-of-stream": "1.4.1",
+                    "once": "1.4.0"
+                  }
+                }
               }
             },
             "stream-each": {
-              "version": "1.2.0",
+              "version": "1.2.2",
               "bundled": true,
               "requires": {
-                "end-of-stream": "1.4.0",
+                "end-of-stream": "1.4.1",
                 "stream-shift": "1.0.0"
               },
               "dependencies": {
@@ -2497,7 +3630,7 @@
               "version": "2.0.3",
               "bundled": true,
               "requires": {
-                "readable-stream": "2.3.3",
+                "readable-stream": "2.3.6",
                 "xtend": "4.0.1"
               },
               "dependencies": {
@@ -2526,31 +3659,37 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "1.1.2",
-            "copy-concurrently": "1.0.3",
+            "aproba": "1.2.0",
+            "copy-concurrently": "1.0.5",
             "fs-write-stream-atomic": "1.0.10",
             "mkdirp": "0.5.1",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "run-queue": "1.0.3"
           },
           "dependencies": {
             "copy-concurrently": {
-              "version": "1.0.3",
+              "version": "1.0.5",
               "bundled": true,
               "requires": {
-                "aproba": "1.1.2",
+                "aproba": "1.2.0",
                 "fs-write-stream-atomic": "1.0.10",
                 "iferr": "0.1.5",
                 "mkdirp": "0.5.1",
-                "rimraf": "2.6.1",
+                "rimraf": "2.6.2",
                 "run-queue": "1.0.3"
+              },
+              "dependencies": {
+                "iferr": {
+                  "version": "0.1.5",
+                  "bundled": true
+                }
               }
             },
             "run-queue": {
               "version": "1.0.3",
               "bundled": true,
               "requires": {
-                "aproba": "1.1.2"
+                "aproba": "1.2.0"
               }
             }
           }
@@ -2566,9 +3705,9 @@
             "mkdirp": "0.5.1",
             "nopt": "3.0.6",
             "npmlog": "4.1.2",
-            "osenv": "0.1.4",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
+            "osenv": "0.1.5",
+            "request": "2.86.0",
+            "rimraf": "2.6.2",
             "semver": "5.3.0",
             "tar": "2.2.1",
             "which": "1.3.0"
@@ -2581,18 +3720,18 @@
                 "graceful-fs": "4.1.11",
                 "inherits": "2.0.3",
                 "mkdirp": "0.5.1",
-                "rimraf": "2.6.1"
+                "rimraf": "2.6.2"
               }
             },
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
               "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "1.1.11"
               },
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.8",
+                  "version": "1.1.11",
                   "bundled": true,
                   "requires": {
                     "balanced-match": "1.0.0",
@@ -2615,7 +3754,7 @@
               "version": "3.0.6",
               "bundled": true,
               "requires": {
-                "abbrev": "1.1.0"
+                "abbrev": "1.1.1"
               }
             },
             "semver": {
@@ -2646,18 +3785,18 @@
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "normalize-package-data": {
           "version": "2.4.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "2.5.0",
+            "hosted-git-info": "2.6.0",
             "is-builtin-module": "1.0.0",
-            "semver": "5.4.1",
-            "validate-npm-package-license": "3.0.1"
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.3"
           },
           "dependencies": {
             "is-builtin-module": {
@@ -2675,6 +3814,20 @@
             }
           }
         },
+        "npm-audit-report": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "cli-table2": "0.2.0",
+            "console-control-strings": "1.1.0"
+          },
+          "dependencies": {
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true
+            }
+          }
+        },
         "npm-cache-filename": {
           "version": "1.0.2",
           "bundled": true
@@ -2683,40 +3836,53 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "semver": "5.4.1"
+            "semver": "5.5.0"
           }
         },
         "npm-lifecycle": {
-          "version": "1.0.2",
+          "version": "2.0.3",
           "bundled": true,
           "requires": {
+            "byline": "5.0.0",
             "graceful-fs": "4.1.11",
+            "node-gyp": "3.6.2",
+            "resolve-from": "4.0.0",
             "slide": "1.1.6",
             "uid-number": "0.0.6",
             "umask": "1.1.0",
             "which": "1.3.0"
+          },
+          "dependencies": {
+            "byline": {
+              "version": "5.0.0",
+              "bundled": true
+            },
+            "resolve-from": {
+              "version": "4.0.0",
+              "bundled": true
+            }
           }
         },
         "npm-package-arg": {
-          "version": "5.1.2",
+          "version": "6.1.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "2.5.0",
-            "osenv": "0.1.4",
-            "semver": "5.4.1",
+            "hosted-git-info": "2.6.0",
+            "osenv": "0.1.5",
+            "semver": "5.5.0",
             "validate-npm-package-name": "3.0.0"
           }
         },
         "npm-packlist": {
-          "version": "1.1.8",
+          "version": "1.1.10",
           "bundled": true,
           "requires": {
-            "ignore-walk": "3.0.0",
+            "ignore-walk": "3.0.1",
             "npm-bundled": "1.0.3"
           },
           "dependencies": {
             "ignore-walk": {
-              "version": "3.0.0",
+              "version": "3.0.1",
               "bundled": true,
               "requires": {
                 "minimatch": "3.0.4"
@@ -2757,35 +3923,1030 @@
             }
           }
         },
-        "npm-registry-client": {
-          "version": "8.4.0",
+        "npm-pick-manifest": {
+          "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "concat-stream": "1.6.0",
+            "npm-package-arg": "6.1.0",
+            "semver": "5.5.0"
+          }
+        },
+        "npm-profile": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "make-fetch-happen": "2.6.0"
+          },
+          "dependencies": {
+            "make-fetch-happen": {
+              "version": "2.6.0",
+              "bundled": true,
+              "requires": {
+                "agentkeepalive": "3.3.0",
+                "cacache": "10.0.4",
+                "http-cache-semantics": "3.8.1",
+                "http-proxy-agent": "2.1.0",
+                "https-proxy-agent": "2.2.1",
+                "lru-cache": "4.1.3",
+                "mississippi": "1.3.1",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "3.0.1",
+                "ssri": "5.3.0"
+              },
+              "dependencies": {
+                "agentkeepalive": {
+                  "version": "3.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "humanize-ms": "1.2.1"
+                  },
+                  "dependencies": {
+                    "humanize-ms": {
+                      "version": "1.2.1",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.1.1"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.1.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "cacache": {
+                  "version": "10.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "bluebird": "3.5.1",
+                    "chownr": "1.0.1",
+                    "glob": "7.1.2",
+                    "graceful-fs": "4.1.11",
+                    "lru-cache": "4.1.3",
+                    "mississippi": "2.0.0",
+                    "mkdirp": "0.5.1",
+                    "move-concurrently": "1.0.1",
+                    "promise-inflight": "1.0.1",
+                    "rimraf": "2.6.2",
+                    "ssri": "5.3.0",
+                    "unique-filename": "1.1.0",
+                    "y18n": "4.0.0"
+                  },
+                  "dependencies": {
+                    "mississippi": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "concat-stream": "1.6.2",
+                        "duplexify": "3.5.4",
+                        "end-of-stream": "1.4.1",
+                        "flush-write-stream": "1.0.3",
+                        "from2": "2.3.0",
+                        "parallel-transform": "1.1.0",
+                        "pump": "2.0.1",
+                        "pumpify": "1.4.0",
+                        "stream-each": "1.2.2",
+                        "through2": "2.0.3"
+                      },
+                      "dependencies": {
+                        "concat-stream": {
+                          "version": "1.6.2",
+                          "bundled": true,
+                          "requires": {
+                            "buffer-from": "1.0.0",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "typedarray": "0.0.6"
+                          },
+                          "dependencies": {
+                            "buffer-from": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            },
+                            "typedarray": {
+                              "version": "0.0.6",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "duplexify": {
+                          "version": "3.5.4",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "end-of-stream": {
+                          "version": "1.4.1",
+                          "bundled": true,
+                          "requires": {
+                            "once": "1.4.0"
+                          }
+                        },
+                        "flush-write-stream": {
+                          "version": "1.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "from2": {
+                          "version": "2.3.0",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "parallel-transform": {
+                          "version": "1.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "cyclist": "0.2.2",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          },
+                          "dependencies": {
+                            "cyclist": {
+                              "version": "0.2.2",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "pump": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
+                          }
+                        },
+                        "pumpify": {
+                          "version": "1.4.0",
+                          "bundled": true,
+                          "requires": {
+                            "duplexify": "3.5.4",
+                            "inherits": "2.0.3",
+                            "pump": "2.0.1"
+                          }
+                        },
+                        "stream-each": {
+                          "version": "1.2.2",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "through2": {
+                          "version": "2.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "readable-stream": "2.3.6",
+                            "xtend": "4.0.1"
+                          },
+                          "dependencies": {
+                            "xtend": {
+                              "version": "4.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "y18n": {
+                      "version": "4.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "http-cache-semantics": {
+                  "version": "3.8.1",
+                  "bundled": true
+                },
+                "http-proxy-agent": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "https-proxy-agent": {
+                  "version": "2.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "mississippi": {
+                  "version": "1.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "concat-stream": "1.6.0",
+                    "duplexify": "3.5.3",
+                    "end-of-stream": "1.4.1",
+                    "flush-write-stream": "1.0.2",
+                    "from2": "2.3.0",
+                    "parallel-transform": "1.1.0",
+                    "pump": "1.0.3",
+                    "pumpify": "1.4.0",
+                    "stream-each": "1.2.2",
+                    "through2": "2.0.3"
+                  },
+                  "dependencies": {
+                    "concat-stream": {
+                      "version": "1.6.0",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6",
+                        "typedarray": "0.0.6"
+                      },
+                      "dependencies": {
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "duplexify": {
+                      "version": "3.5.3",
+                      "bundled": true,
+                      "requires": {
+                        "end-of-stream": "1.4.1",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6",
+                        "stream-shift": "1.0.0"
+                      },
+                      "dependencies": {
+                        "stream-shift": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "end-of-stream": {
+                      "version": "1.4.1",
+                      "bundled": true,
+                      "requires": {
+                        "once": "1.4.0"
+                      }
+                    },
+                    "flush-write-stream": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6"
+                      }
+                    },
+                    "from2": {
+                      "version": "2.3.0",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6"
+                      }
+                    },
+                    "parallel-transform": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "cyclist": "0.2.2",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6"
+                      },
+                      "dependencies": {
+                        "cyclist": {
+                          "version": "0.2.2",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "pump": {
+                      "version": "1.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "end-of-stream": "1.4.1",
+                        "once": "1.4.0"
+                      }
+                    },
+                    "pumpify": {
+                      "version": "1.4.0",
+                      "bundled": true,
+                      "requires": {
+                        "duplexify": "3.5.3",
+                        "inherits": "2.0.3",
+                        "pump": "2.0.1"
+                      },
+                      "dependencies": {
+                        "pump": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
+                          }
+                        }
+                      }
+                    },
+                    "stream-each": {
+                      "version": "1.2.2",
+                      "bundled": true,
+                      "requires": {
+                        "end-of-stream": "1.4.1",
+                        "stream-shift": "1.0.0"
+                      },
+                      "dependencies": {
+                        "stream-shift": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "through2": {
+                      "version": "2.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "readable-stream": "2.3.6",
+                        "xtend": "4.0.1"
+                      },
+                      "dependencies": {
+                        "xtend": {
+                          "version": "4.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "node-fetch-npm": {
+                  "version": "2.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "encoding": "0.1.12",
+                    "json-parse-better-errors": "1.0.1",
+                    "safe-buffer": "5.1.2"
+                  },
+                  "dependencies": {
+                    "encoding": {
+                      "version": "0.1.12",
+                      "bundled": true,
+                      "requires": {
+                        "iconv-lite": "0.4.19"
+                      },
+                      "dependencies": {
+                        "iconv-lite": {
+                          "version": "0.4.19",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "json-parse-better-errors": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "promise-retry": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "err-code": "1.1.2",
+                    "retry": "0.10.1"
+                  },
+                  "dependencies": {
+                    "err-code": {
+                      "version": "1.1.2",
+                      "bundled": true
+                    },
+                    "retry": {
+                      "version": "0.10.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "socks-proxy-agent": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "socks": "1.1.10"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "socks": {
+                      "version": "1.1.10",
+                      "bundled": true,
+                      "requires": {
+                        "ip": "1.1.5",
+                        "smart-buffer": "1.1.15"
+                      },
+                      "dependencies": {
+                        "ip": {
+                          "version": "1.1.5",
+                          "bundled": true
+                        },
+                        "smart-buffer": {
+                          "version": "1.1.15",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "ssri": {
+                  "version": "5.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "safe-buffer": "5.1.2"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "npm-registry-client": {
+          "version": "8.5.1",
+          "bundled": true,
+          "requires": {
+            "concat-stream": "1.6.1",
             "graceful-fs": "4.1.11",
             "normalize-package-data": "2.4.0",
-            "npm-package-arg": "5.1.2",
+            "npm-package-arg": "6.1.0",
             "npmlog": "4.1.2",
             "once": "1.4.0",
-            "request": "2.81.0",
+            "request": "2.86.0",
             "retry": "0.10.1",
-            "semver": "5.4.1",
+            "safe-buffer": "5.1.2",
+            "semver": "5.5.0",
             "slide": "1.1.6",
-            "ssri": "4.1.6"
+            "ssri": "5.3.0"
           },
           "dependencies": {
             "concat-stream": {
-              "version": "1.6.0",
+              "version": "1.6.1",
               "bundled": true,
               "requires": {
                 "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
+                "readable-stream": "2.3.6",
                 "typedarray": "0.0.6"
               },
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
                   "bundled": true
+                }
+              }
+            },
+            "retry": {
+              "version": "0.10.1",
+              "bundled": true
+            },
+            "ssri": {
+              "version": "5.3.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.2"
+              }
+            }
+          }
+        },
+        "npm-registry-fetch": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "bluebird": "3.5.1",
+            "figgy-pudding": "2.0.1",
+            "lru-cache": "4.1.3",
+            "make-fetch-happen": "3.0.0",
+            "npm-package-arg": "6.1.0",
+            "safe-buffer": "5.1.2"
+          },
+          "dependencies": {
+            "figgy-pudding": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "make-fetch-happen": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "agentkeepalive": "3.4.1",
+                "cacache": "10.0.4",
+                "http-cache-semantics": "3.8.1",
+                "http-proxy-agent": "2.1.0",
+                "https-proxy-agent": "2.2.1",
+                "lru-cache": "4.1.3",
+                "mississippi": "3.0.0",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "3.0.1",
+                "ssri": "5.3.0"
+              },
+              "dependencies": {
+                "agentkeepalive": {
+                  "version": "3.4.1",
+                  "bundled": true,
+                  "requires": {
+                    "humanize-ms": "1.2.1"
+                  },
+                  "dependencies": {
+                    "humanize-ms": {
+                      "version": "1.2.1",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.1.1"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.1.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "cacache": {
+                  "version": "10.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "bluebird": "3.5.1",
+                    "chownr": "1.0.1",
+                    "glob": "7.1.2",
+                    "graceful-fs": "4.1.11",
+                    "lru-cache": "4.1.3",
+                    "mississippi": "2.0.0",
+                    "mkdirp": "0.5.1",
+                    "move-concurrently": "1.0.1",
+                    "promise-inflight": "1.0.1",
+                    "rimraf": "2.6.2",
+                    "ssri": "5.3.0",
+                    "unique-filename": "1.1.0",
+                    "y18n": "4.0.0"
+                  },
+                  "dependencies": {
+                    "mississippi": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "concat-stream": "1.6.2",
+                        "duplexify": "3.5.4",
+                        "end-of-stream": "1.4.1",
+                        "flush-write-stream": "1.0.3",
+                        "from2": "2.3.0",
+                        "parallel-transform": "1.1.0",
+                        "pump": "2.0.1",
+                        "pumpify": "1.4.0",
+                        "stream-each": "1.2.2",
+                        "through2": "2.0.3"
+                      },
+                      "dependencies": {
+                        "concat-stream": {
+                          "version": "1.6.2",
+                          "bundled": true,
+                          "requires": {
+                            "buffer-from": "1.0.0",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "typedarray": "0.0.6"
+                          },
+                          "dependencies": {
+                            "buffer-from": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            },
+                            "typedarray": {
+                              "version": "0.0.6",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "duplexify": {
+                          "version": "3.5.4",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "end-of-stream": {
+                          "version": "1.4.1",
+                          "bundled": true,
+                          "requires": {
+                            "once": "1.4.0"
+                          }
+                        },
+                        "flush-write-stream": {
+                          "version": "1.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "from2": {
+                          "version": "2.3.0",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "parallel-transform": {
+                          "version": "1.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "cyclist": "0.2.2",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          },
+                          "dependencies": {
+                            "cyclist": {
+                              "version": "0.2.2",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "pump": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
+                          }
+                        },
+                        "pumpify": {
+                          "version": "1.4.0",
+                          "bundled": true,
+                          "requires": {
+                            "duplexify": "3.5.4",
+                            "inherits": "2.0.3",
+                            "pump": "2.0.1"
+                          }
+                        },
+                        "stream-each": {
+                          "version": "1.2.2",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "through2": {
+                          "version": "2.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "readable-stream": "2.3.6",
+                            "xtend": "4.0.1"
+                          },
+                          "dependencies": {
+                            "xtend": {
+                              "version": "4.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "y18n": {
+                      "version": "4.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "http-cache-semantics": {
+                  "version": "3.8.1",
+                  "bundled": true
+                },
+                "http-proxy-agent": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "https-proxy-agent": {
+                  "version": "2.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "node-fetch-npm": {
+                  "version": "2.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "encoding": "0.1.12",
+                    "json-parse-better-errors": "1.0.2",
+                    "safe-buffer": "5.1.2"
+                  },
+                  "dependencies": {
+                    "encoding": {
+                      "version": "0.1.12",
+                      "bundled": true,
+                      "requires": {
+                        "iconv-lite": "0.4.21"
+                      },
+                      "dependencies": {
+                        "iconv-lite": {
+                          "version": "0.4.21",
+                          "bundled": true,
+                          "requires": {
+                            "safer-buffer": "2.1.2"
+                          },
+                          "dependencies": {
+                            "safer-buffer": {
+                              "version": "2.1.2",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "promise-retry": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "err-code": "1.1.2",
+                    "retry": "0.10.1"
+                  },
+                  "dependencies": {
+                    "err-code": {
+                      "version": "1.1.2",
+                      "bundled": true
+                    },
+                    "retry": {
+                      "version": "0.10.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "socks-proxy-agent": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "socks": "1.1.10"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "socks": {
+                      "version": "1.1.10",
+                      "bundled": true,
+                      "requires": {
+                        "ip": "1.1.5",
+                        "smart-buffer": "1.1.15"
+                      },
+                      "dependencies": {
+                        "ip": {
+                          "version": "1.1.5",
+                          "bundled": true
+                        },
+                        "smart-buffer": {
+                          "version": "1.1.15",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "ssri": {
+                  "version": "5.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "safe-buffer": "5.1.2"
+                  }
                 }
               }
             }
@@ -2810,7 +4971,7 @@
               "bundled": true,
               "requires": {
                 "delegates": "1.0.0",
-                "readable-stream": "2.3.3"
+                "readable-stream": "2.3.6"
               },
               "dependencies": {
                 "delegates": {
@@ -2827,7 +4988,7 @@
               "version": "2.7.4",
               "bundled": true,
               "requires": {
-                "aproba": "1.1.2",
+                "aproba": "1.2.0",
                 "console-control-strings": "1.1.0",
                 "has-unicode": "2.0.1",
                 "object-assign": "4.1.1",
@@ -2913,7 +5074,7 @@
           "bundled": true
         },
         "osenv": {
-          "version": "0.1.4",
+          "version": "0.1.5",
           "bundled": true,
           "requires": {
             "os-homedir": "1.0.2",
@@ -2931,51 +5092,59 @@
           }
         },
         "pacote": {
-          "version": "6.0.2",
+          "version": "8.1.5",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.0",
-            "cacache": "9.2.9",
+            "bluebird": "3.5.1",
+            "cacache": "11.0.2",
+            "get-stream": "3.0.0",
             "glob": "7.1.2",
-            "lru-cache": "4.1.1",
-            "make-fetch-happen": "2.5.0",
+            "lru-cache": "4.1.3",
+            "make-fetch-happen": "4.0.1",
             "minimatch": "3.0.4",
-            "mississippi": "1.3.0",
+            "minipass": "2.3.3",
+            "mississippi": "3.0.0",
+            "mkdirp": "0.5.1",
             "normalize-package-data": "2.4.0",
-            "npm-package-arg": "5.1.2",
-            "npm-packlist": "1.1.8",
-            "npm-pick-manifest": "1.0.4",
-            "osenv": "0.1.4",
+            "npm-package-arg": "6.1.0",
+            "npm-packlist": "1.1.10",
+            "npm-pick-manifest": "2.1.0",
+            "osenv": "0.1.5",
             "promise-inflight": "1.0.1",
             "promise-retry": "1.1.1",
-            "protoduck": "4.0.0",
-            "safe-buffer": "5.1.1",
-            "semver": "5.4.1",
-            "ssri": "4.1.6",
-            "tar": "4.0.1",
+            "protoduck": "5.0.0",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.2",
+            "semver": "5.5.0",
+            "ssri": "6.0.0",
+            "tar": "4.4.1",
             "unique-filename": "1.1.0",
             "which": "1.3.0"
           },
           "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            },
             "make-fetch-happen": {
-              "version": "2.5.0",
+              "version": "4.0.1",
               "bundled": true,
               "requires": {
-                "agentkeepalive": "3.3.0",
-                "cacache": "9.2.9",
-                "http-cache-semantics": "3.7.3",
-                "http-proxy-agent": "2.0.0",
-                "https-proxy-agent": "2.1.0",
-                "lru-cache": "4.1.1",
-                "mississippi": "1.3.0",
+                "agentkeepalive": "3.4.1",
+                "cacache": "11.0.2",
+                "http-cache-semantics": "3.8.1",
+                "http-proxy-agent": "2.1.0",
+                "https-proxy-agent": "2.2.1",
+                "lru-cache": "4.1.3",
+                "mississippi": "3.0.0",
                 "node-fetch-npm": "2.0.2",
                 "promise-retry": "1.1.1",
-                "socks-proxy-agent": "3.0.0",
-                "ssri": "4.1.6"
+                "socks-proxy-agent": "4.0.1",
+                "ssri": "6.0.0"
               },
               "dependencies": {
                 "agentkeepalive": {
-                  "version": "3.3.0",
+                  "version": "3.4.1",
                   "bundled": true,
                   "requires": {
                     "humanize-ms": "1.2.1"
@@ -2985,11 +5154,11 @@
                       "version": "1.2.1",
                       "bundled": true,
                       "requires": {
-                        "ms": "2.0.0"
+                        "ms": "2.1.1"
                       },
                       "dependencies": {
                         "ms": {
-                          "version": "2.0.0",
+                          "version": "2.1.1",
                           "bundled": true
                         }
                       }
@@ -2997,19 +5166,19 @@
                   }
                 },
                 "http-cache-semantics": {
-                  "version": "3.7.3",
+                  "version": "3.8.1",
                   "bundled": true
                 },
                 "http-proxy-agent": {
-                  "version": "2.0.0",
+                  "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.1.1",
-                    "debug": "2.6.8"
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
                   },
                   "dependencies": {
                     "agent-base": {
-                      "version": "4.1.1",
+                      "version": "4.2.0",
                       "bundled": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
@@ -3019,11 +5188,11 @@
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.1.1"
+                            "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
-                              "version": "4.1.1",
+                              "version": "4.2.4",
                               "bundled": true
                             }
                           }
@@ -3031,7 +5200,7 @@
                       }
                     },
                     "debug": {
-                      "version": "2.6.8",
+                      "version": "3.1.0",
                       "bundled": true,
                       "requires": {
                         "ms": "2.0.0"
@@ -3046,15 +5215,15 @@
                   }
                 },
                 "https-proxy-agent": {
-                  "version": "2.1.0",
+                  "version": "2.2.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.1.1",
-                    "debug": "2.6.8"
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
                   },
                   "dependencies": {
                     "agent-base": {
-                      "version": "4.1.1",
+                      "version": "4.2.0",
                       "bundled": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
@@ -3064,11 +5233,11 @@
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.1.1"
+                            "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
-                              "version": "4.1.1",
+                              "version": "4.2.4",
                               "bundled": true
                             }
                           }
@@ -3076,7 +5245,7 @@
                       }
                     },
                     "debug": {
-                      "version": "2.6.8",
+                      "version": "3.1.0",
                       "bundled": true,
                       "requires": {
                         "ms": "2.0.0"
@@ -3095,39 +5264,44 @@
                   "bundled": true,
                   "requires": {
                     "encoding": "0.1.12",
-                    "json-parse-better-errors": "1.0.1",
-                    "safe-buffer": "5.1.1"
+                    "json-parse-better-errors": "1.0.2",
+                    "safe-buffer": "5.1.2"
                   },
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
                       "bundled": true,
                       "requires": {
-                        "iconv-lite": "0.4.18"
+                        "iconv-lite": "0.4.23"
                       },
                       "dependencies": {
                         "iconv-lite": {
-                          "version": "0.4.18",
-                          "bundled": true
+                          "version": "0.4.23",
+                          "bundled": true,
+                          "requires": {
+                            "safer-buffer": "2.1.2"
+                          },
+                          "dependencies": {
+                            "safer-buffer": {
+                              "version": "2.1.2",
+                              "bundled": true
+                            }
+                          }
                         }
                       }
-                    },
-                    "json-parse-better-errors": {
-                      "version": "1.0.1",
-                      "bundled": true
                     }
                   }
                 },
                 "socks-proxy-agent": {
-                  "version": "3.0.0",
+                  "version": "4.0.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.1.1",
-                    "socks": "1.1.10"
+                    "agent-base": "4.2.0",
+                    "socks": "2.2.0"
                   },
                   "dependencies": {
                     "agent-base": {
-                      "version": "4.1.1",
+                      "version": "4.2.0",
                       "bundled": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
@@ -3137,11 +5311,11 @@
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.1.1"
+                            "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
-                              "version": "4.1.1",
+                              "version": "4.2.4",
                               "bundled": true
                             }
                           }
@@ -3149,11 +5323,11 @@
                       }
                     },
                     "socks": {
-                      "version": "1.1.10",
+                      "version": "2.2.0",
                       "bundled": true,
                       "requires": {
                         "ip": "1.1.5",
-                        "smart-buffer": "1.1.15"
+                        "smart-buffer": "4.0.1"
                       },
                       "dependencies": {
                         "ip": {
@@ -3161,7 +5335,7 @@
                           "bundled": true
                         },
                         "smart-buffer": {
-                          "version": "1.1.15",
+                          "version": "4.0.1",
                           "bundled": true
                         }
                       }
@@ -3174,11 +5348,11 @@
               "version": "3.0.4",
               "bundled": true,
               "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "1.1.11"
               },
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.8",
+                  "version": "1.1.11",
                   "bundled": true,
                   "requires": {
                     "balanced-match": "1.0.0",
@@ -3197,12 +5371,18 @@
                 }
               }
             },
-            "npm-pick-manifest": {
-              "version": "1.0.4",
+            "minipass": {
+              "version": "2.3.3",
               "bundled": true,
               "requires": {
-                "npm-package-arg": "5.1.2",
-                "semver": "5.4.1"
+                "safe-buffer": "5.1.2",
+                "yallist": "3.0.2"
+              },
+              "dependencies": {
+                "yallist": {
+                  "version": "3.0.2",
+                  "bundled": true
+                }
               }
             },
             "promise-retry": {
@@ -3216,11 +5396,15 @@
                 "err-code": {
                   "version": "1.1.2",
                   "bundled": true
+                },
+                "retry": {
+                  "version": "0.10.1",
+                  "bundled": true
                 }
               }
             },
             "protoduck": {
-              "version": "4.0.0",
+              "version": "5.0.0",
               "bundled": true,
               "requires": {
                 "genfun": "4.0.1"
@@ -3239,6 +5423,32 @@
           "bundled": true
         },
         "promise-inflight": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "qrcode-terminal": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "query-string": {
+          "version": "6.1.0",
+          "bundled": true,
+          "requires": {
+            "decode-uri-component": "0.2.0",
+            "strict-uri-encode": "2.0.0"
+          },
+          "dependencies": {
+            "decode-uri-component": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "strict-uri-encode": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "qw": {
           "version": "1.0.1",
           "bundled": true
         },
@@ -3268,9 +5478,9 @@
           "requires": {
             "debuglog": "1.0.1",
             "graceful-fs": "4.1.11",
-            "read-package-json": "2.0.12",
+            "read-package-json": "2.0.13",
             "readdir-scoped-modules": "1.0.2",
-            "semver": "5.4.1",
+            "semver": "5.5.0",
             "slide": "1.1.6",
             "util-extend": "1.0.3"
           },
@@ -3282,7 +5492,7 @@
           }
         },
         "read-package-json": {
-          "version": "2.0.12",
+          "version": "2.0.13",
           "bundled": true,
           "requires": {
             "glob": "7.1.2",
@@ -3303,26 +5513,26 @@
           }
         },
         "read-package-tree": {
-          "version": "5.1.6",
+          "version": "5.2.1",
           "bundled": true,
           "requires": {
             "debuglog": "1.0.1",
             "dezalgo": "1.0.3",
             "once": "1.4.0",
-            "read-package-json": "2.0.12",
+            "read-package-json": "2.0.13",
             "readdir-scoped-modules": "1.0.2"
           }
         },
         "readable-stream": {
-          "version": "2.3.3",
+          "version": "2.3.6",
           "bundled": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
             "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
             "util-deprecate": "1.0.2"
           },
           "dependencies": {
@@ -3335,14 +5545,14 @@
               "bundled": true
             },
             "process-nextick-args": {
-              "version": "1.0.7",
+              "version": "2.0.0",
               "bundled": true
             },
             "string_decoder": {
-              "version": "1.0.3",
+              "version": "1.1.1",
               "bundled": true,
               "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
               }
             },
             "util-deprecate": {
@@ -3362,39 +5572,38 @@
           }
         },
         "request": {
-          "version": "2.81.0",
+          "version": "2.86.0",
           "bundled": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
+            "aws-sign2": "0.7.0",
+            "aws4": "1.7.0",
             "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
+            "combined-stream": "1.0.6",
             "extend": "3.0.1",
             "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
             "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
             "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
+            "mime-types": "2.1.18",
             "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.2",
+            "safe-buffer": "5.1.2",
+            "tough-cookie": "2.3.4",
             "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
+            "uuid": "3.2.1"
           },
           "dependencies": {
             "aws-sign2": {
-              "version": "0.6.0",
+              "version": "0.7.0",
               "bundled": true
             },
             "aws4": {
-              "version": "1.6.0",
+              "version": "1.7.0",
               "bundled": true
             },
             "caseless": {
@@ -3402,7 +5611,7 @@
               "bundled": true
             },
             "combined-stream": {
-              "version": "1.0.5",
+              "version": "1.0.6",
               "bundled": true,
               "requires": {
                 "delayed-stream": "1.0.0"
@@ -3423,12 +5632,12 @@
               "bundled": true
             },
             "form-data": {
-              "version": "2.1.4",
+              "version": "2.3.2",
               "bundled": true,
               "requires": {
                 "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.15"
+                "combined-stream": "1.0.6",
+                "mime-types": "2.1.18"
               },
               "dependencies": {
                 "asynckit": {
@@ -3438,112 +5647,118 @@
               }
             },
             "har-validator": {
-              "version": "4.2.1",
+              "version": "5.0.3",
               "bundled": true,
               "requires": {
-                "ajv": "4.11.8",
-                "har-schema": "1.0.5"
+                "ajv": "5.5.2",
+                "har-schema": "2.0.0"
               },
               "dependencies": {
                 "ajv": {
-                  "version": "4.11.8",
+                  "version": "5.5.2",
                   "bundled": true,
                   "requires": {
                     "co": "4.6.0",
-                    "json-stable-stringify": "1.0.1"
+                    "fast-deep-equal": "1.1.0",
+                    "fast-json-stable-stringify": "2.0.0",
+                    "json-schema-traverse": "0.3.1"
                   },
                   "dependencies": {
                     "co": {
                       "version": "4.6.0",
                       "bundled": true
                     },
-                    "json-stable-stringify": {
-                      "version": "1.0.1",
-                      "bundled": true,
-                      "requires": {
-                        "jsonify": "0.0.0"
-                      },
-                      "dependencies": {
-                        "jsonify": {
-                          "version": "0.0.0",
-                          "bundled": true
-                        }
-                      }
+                    "fast-deep-equal": {
+                      "version": "1.1.0",
+                      "bundled": true
+                    },
+                    "fast-json-stable-stringify": {
+                      "version": "2.0.0",
+                      "bundled": true
+                    },
+                    "json-schema-traverse": {
+                      "version": "0.3.1",
+                      "bundled": true
                     }
                   }
                 },
                 "har-schema": {
-                  "version": "1.0.5",
+                  "version": "2.0.0",
                   "bundled": true
                 }
               }
             },
             "hawk": {
-              "version": "3.1.3",
+              "version": "6.0.2",
               "bundled": true,
               "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.1",
+                "sntp": "2.1.0"
               },
               "dependencies": {
                 "boom": {
-                  "version": "2.10.1",
+                  "version": "4.3.1",
                   "bundled": true,
                   "requires": {
-                    "hoek": "2.16.3"
+                    "hoek": "4.2.1"
                   }
                 },
                 "cryptiles": {
-                  "version": "2.0.5",
+                  "version": "3.1.2",
                   "bundled": true,
                   "requires": {
-                    "boom": "2.10.1"
+                    "boom": "5.2.0"
+                  },
+                  "dependencies": {
+                    "boom": {
+                      "version": "5.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "4.2.1"
+                      }
+                    }
                   }
                 },
                 "hoek": {
-                  "version": "2.16.3",
+                  "version": "4.2.1",
                   "bundled": true
                 },
                 "sntp": {
-                  "version": "1.0.9",
+                  "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "hoek": "2.16.3"
+                    "hoek": "4.2.1"
                   }
                 }
               }
             },
             "http-signature": {
-              "version": "1.1.1",
+              "version": "1.2.0",
               "bundled": true,
               "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.0",
-                "sshpk": "1.13.1"
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.14.1"
               },
               "dependencies": {
                 "assert-plus": {
-                  "version": "0.2.0",
+                  "version": "1.0.0",
                   "bundled": true
                 },
                 "jsprim": {
-                  "version": "1.4.0",
+                  "version": "1.4.1",
                   "bundled": true,
                   "requires": {
                     "assert-plus": "1.0.0",
-                    "extsprintf": "1.0.2",
+                    "extsprintf": "1.3.0",
                     "json-schema": "0.2.3",
-                    "verror": "1.3.6"
+                    "verror": "1.10.0"
                   },
                   "dependencies": {
-                    "assert-plus": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
                     "extsprintf": {
-                      "version": "1.0.2",
+                      "version": "1.3.0",
                       "bundled": true
                     },
                     "json-schema": {
@@ -3551,16 +5766,24 @@
                       "bundled": true
                     },
                     "verror": {
-                      "version": "1.3.6",
+                      "version": "1.10.0",
                       "bundled": true,
                       "requires": {
-                        "extsprintf": "1.0.2"
+                        "assert-plus": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "extsprintf": "1.3.0"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        }
                       }
                     }
                   }
                 },
                 "sshpk": {
-                  "version": "1.13.1",
+                  "version": "1.14.1",
                   "bundled": true,
                   "requires": {
                     "asn1": "0.2.3",
@@ -3575,10 +5798,6 @@
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
-                      "bundled": true
-                    },
-                    "assert-plus": {
-                      "version": "1.0.0",
                       "bundled": true
                     },
                     "bcrypt-pbkdf": {
@@ -3638,14 +5857,14 @@
               "bundled": true
             },
             "mime-types": {
-              "version": "2.1.15",
+              "version": "2.1.18",
               "bundled": true,
               "requires": {
-                "mime-db": "1.27.0"
+                "mime-db": "1.33.0"
               },
               "dependencies": {
                 "mime-db": {
-                  "version": "1.27.0",
+                  "version": "1.33.0",
                   "bundled": true
                 }
               }
@@ -3655,19 +5874,15 @@
               "bundled": true
             },
             "performance-now": {
-              "version": "0.2.0",
+              "version": "2.1.0",
               "bundled": true
             },
             "qs": {
-              "version": "6.4.0",
-              "bundled": true
-            },
-            "stringstream": {
-              "version": "0.0.5",
+              "version": "6.5.2",
               "bundled": true
             },
             "tough-cookie": {
-              "version": "2.3.2",
+              "version": "2.3.4",
               "bundled": true,
               "requires": {
                 "punycode": "1.4.1"
@@ -3683,28 +5898,28 @@
               "version": "0.6.0",
               "bundled": true,
               "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
               }
             }
           }
         },
         "retry": {
-          "version": "0.10.1",
+          "version": "0.12.0",
           "bundled": true
         },
         "rimraf": {
-          "version": "2.6.1",
+          "version": "2.6.2",
           "bundled": true,
           "requires": {
             "glob": "7.1.2"
           }
         },
         "safe-buffer": {
-          "version": "5.1.1",
+          "version": "5.1.2",
           "bundled": true
         },
         "semver": {
-          "version": "5.4.1",
+          "version": "5.5.0",
           "bundled": true
         },
         "sha": {
@@ -3712,7 +5927,7 @@
           "bundled": true,
           "requires": {
             "graceful-fs": "4.1.11",
-            "readable-stream": "2.3.3"
+            "readable-stream": "2.3.6"
           }
         },
         "slide": {
@@ -3769,7 +5984,7 @@
               "version": "1.2.0",
               "bundled": true,
               "requires": {
-                "readable-stream": "2.3.3",
+                "readable-stream": "2.3.6",
                 "stream-shift": "1.0.0"
               },
               "dependencies": {
@@ -3782,11 +5997,8 @@
           }
         },
         "ssri": {
-          "version": "4.1.6",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "version": "6.0.0",
+          "bundled": true
         },
         "strip-ansi": {
           "version": "4.0.0",
@@ -3802,28 +6014,38 @@
           }
         },
         "tar": {
-          "version": "4.0.1",
+          "version": "4.4.1",
           "bundled": true,
           "requires": {
             "chownr": "1.0.1",
-            "minipass": "2.2.1",
-            "minizlib": "1.0.3",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.3.1",
+            "minizlib": "1.1.0",
             "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
             "yallist": "3.0.2"
           },
           "dependencies": {
-            "minipass": {
-              "version": "2.2.1",
+            "fs-minipass": {
+              "version": "1.2.5",
               "bundled": true,
               "requires": {
+                "minipass": "2.3.1"
+              }
+            },
+            "minipass": {
+              "version": "2.3.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.2",
                 "yallist": "3.0.2"
               }
             },
             "minizlib": {
-              "version": "1.0.3",
+              "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "minipass": "2.2.1"
+                "minipass": "2.3.1"
               }
             },
             "yallist": {
@@ -3834,6 +6056,10 @@
         },
         "text-table": {
           "version": "0.2.0",
+          "bundled": true
+        },
+        "tiny-relative-date": {
+          "version": "1.3.0",
           "bundled": true
         },
         "uid-number": {
@@ -3865,13 +6091,15 @@
           "bundled": true
         },
         "update-notifier": {
-          "version": "2.2.0",
+          "version": "2.5.0",
           "bundled": true,
           "requires": {
-            "boxen": "1.1.0",
-            "chalk": "1.1.3",
-            "configstore": "3.1.0",
+            "boxen": "1.3.0",
+            "chalk": "2.4.1",
+            "configstore": "3.1.2",
             "import-lazy": "2.1.0",
+            "is-ci": "1.1.0",
+            "is-installed-globally": "0.1.0",
             "is-npm": "1.0.0",
             "latest-version": "3.1.0",
             "semver-diff": "2.1.0",
@@ -3879,23 +6107,23 @@
           },
           "dependencies": {
             "boxen": {
-              "version": "1.1.0",
+              "version": "1.3.0",
               "bundled": true,
               "requires": {
                 "ansi-align": "2.0.0",
                 "camelcase": "4.1.0",
-                "chalk": "1.1.3",
+                "chalk": "2.4.1",
                 "cli-boxes": "1.0.0",
-                "string-width": "2.1.0",
-                "term-size": "0.1.1",
-                "widest-line": "1.0.0"
+                "string-width": "2.1.1",
+                "term-size": "1.2.0",
+                "widest-line": "2.0.0"
               },
               "dependencies": {
                 "ansi-align": {
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "string-width": "2.1.0"
+                    "string-width": "2.1.1"
                   }
                 },
                 "camelcase": {
@@ -3907,7 +6135,7 @@
                   "bundled": true
                 },
                 "string-width": {
-                  "version": "2.1.0",
+                  "version": "2.1.1",
                   "bundled": true,
                   "requires": {
                     "is-fullwidth-code-point": "2.0.0",
@@ -3917,60 +6145,80 @@
                     "is-fullwidth-code-point": {
                       "version": "2.0.0",
                       "bundled": true
-                    },
-                    "strip-ansi": {
-                      "version": "4.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "ansi-regex": "3.0.0"
-                      }
                     }
                   }
                 },
                 "term-size": {
-                  "version": "0.1.1",
+                  "version": "1.2.0",
                   "bundled": true,
                   "requires": {
-                    "execa": "0.4.0"
+                    "execa": "0.7.0"
                   },
                   "dependencies": {
                     "execa": {
-                      "version": "0.4.0",
+                      "version": "0.7.0",
                       "bundled": true,
                       "requires": {
-                        "cross-spawn-async": "2.2.5",
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
                         "is-stream": "1.1.0",
-                        "npm-run-path": "1.0.0",
-                        "object-assign": "4.1.1",
-                        "path-key": "1.0.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
                         "strip-eof": "1.0.0"
                       },
                       "dependencies": {
-                        "cross-spawn-async": {
-                          "version": "2.2.5",
+                        "cross-spawn": {
+                          "version": "5.1.0",
                           "bundled": true,
                           "requires": {
-                            "lru-cache": "4.1.1",
+                            "lru-cache": "4.1.3",
+                            "shebang-command": "1.2.0",
                             "which": "1.3.0"
+                          },
+                          "dependencies": {
+                            "shebang-command": {
+                              "version": "1.2.0",
+                              "bundled": true,
+                              "requires": {
+                                "shebang-regex": "1.0.0"
+                              },
+                              "dependencies": {
+                                "shebang-regex": {
+                                  "version": "1.0.0",
+                                  "bundled": true
+                                }
+                              }
+                            }
                           }
+                        },
+                        "get-stream": {
+                          "version": "3.0.0",
+                          "bundled": true
                         },
                         "is-stream": {
                           "version": "1.1.0",
                           "bundled": true
                         },
                         "npm-run-path": {
-                          "version": "1.0.0",
+                          "version": "2.0.2",
                           "bundled": true,
                           "requires": {
-                            "path-key": "1.0.0"
+                            "path-key": "2.0.1"
+                          },
+                          "dependencies": {
+                            "path-key": {
+                              "version": "2.0.1",
+                              "bundled": true
+                            }
                           }
                         },
-                        "object-assign": {
-                          "version": "4.1.1",
+                        "p-finally": {
+                          "version": "1.0.0",
                           "bundled": true
                         },
-                        "path-key": {
-                          "version": "1.0.0",
+                        "signal-exit": {
+                          "version": "3.0.2",
                           "bundled": true
                         },
                         "strip-eof": {
@@ -3982,122 +6230,78 @@
                   }
                 },
                 "widest-line": {
-                  "version": "1.0.0",
+                  "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "string-width": "1.0.2"
-                  },
-                  "dependencies": {
-                    "string-width": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                      },
-                      "dependencies": {
-                        "code-point-at": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "is-fullwidth-code-point": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "number-is-nan": "1.0.1"
-                          },
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.1",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "bundled": true,
-                          "requires": {
-                            "ansi-regex": "2.1.1"
-                          },
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.1.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
+                    "string-width": "2.1.1"
                   }
                 }
               }
             },
             "chalk": {
-              "version": "1.1.3",
+              "version": "2.4.1",
               "bundled": true,
               "requires": {
-                "ansi-styles": "2.2.1",
+                "ansi-styles": "3.2.1",
                 "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "supports-color": "5.4.0"
               },
               "dependencies": {
                 "ansi-styles": {
-                  "version": "2.2.1",
-                  "bundled": true
+                  "version": "3.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "color-convert": "1.9.1"
+                  },
+                  "dependencies": {
+                    "color-convert": {
+                      "version": "1.9.1",
+                      "bundled": true,
+                      "requires": {
+                        "color-name": "1.1.3"
+                      },
+                      "dependencies": {
+                        "color-name": {
+                          "version": "1.1.3",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
                   "bundled": true
                 },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "bundled": true
-                    }
-                  }
-                },
                 "supports-color": {
-                  "version": "2.0.0",
-                  "bundled": true
+                  "version": "5.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "3.0.0"
+                  },
+                  "dependencies": {
+                    "has-flag": {
+                      "version": "3.0.0",
+                      "bundled": true
+                    }
+                  }
                 }
               }
             },
             "configstore": {
-              "version": "3.1.0",
+              "version": "3.1.2",
               "bundled": true,
               "requires": {
-                "dot-prop": "4.1.1",
+                "dot-prop": "4.2.0",
                 "graceful-fs": "4.1.11",
-                "make-dir": "1.0.0",
+                "make-dir": "1.2.0",
                 "unique-string": "1.0.0",
-                "write-file-atomic": "2.1.0",
+                "write-file-atomic": "2.3.0",
                 "xdg-basedir": "3.0.0"
               },
               "dependencies": {
                 "dot-prop": {
-                  "version": "4.1.1",
+                  "version": "4.2.0",
                   "bundled": true,
                   "requires": {
                     "is-obj": "1.0.1"
@@ -4110,14 +6314,14 @@
                   }
                 },
                 "make-dir": {
-                  "version": "1.0.0",
+                  "version": "1.2.0",
                   "bundled": true,
                   "requires": {
-                    "pify": "2.3.0"
+                    "pify": "3.0.0"
                   },
                   "dependencies": {
                     "pify": {
-                      "version": "2.3.0",
+                      "version": "3.0.0",
                       "bundled": true
                     }
                   }
@@ -4141,6 +6345,43 @@
               "version": "2.1.0",
               "bundled": true
             },
+            "is-ci": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "ci-info": "1.1.3"
+              },
+              "dependencies": {
+                "ci-info": {
+                  "version": "1.1.3",
+                  "bundled": true
+                }
+              }
+            },
+            "is-installed-globally": {
+              "version": "0.1.0",
+              "bundled": true,
+              "requires": {
+                "global-dirs": "0.1.1",
+                "is-path-inside": "1.0.1"
+              },
+              "dependencies": {
+                "global-dirs": {
+                  "version": "0.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "ini": "1.3.5"
+                  }
+                },
+                "is-path-inside": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "path-is-inside": "1.0.2"
+                  }
+                }
+              }
+            },
             "is-npm": {
               "version": "1.0.0",
               "bundled": true
@@ -4157,9 +6398,9 @@
                   "bundled": true,
                   "requires": {
                     "got": "6.7.1",
-                    "registry-auth-token": "3.3.1",
+                    "registry-auth-token": "3.3.2",
                     "registry-url": "3.1.0",
-                    "semver": "5.4.1"
+                    "semver": "5.5.0"
                   },
                   "dependencies": {
                     "got": {
@@ -4172,8 +6413,8 @@
                         "is-redirect": "1.0.0",
                         "is-retry-allowed": "1.1.0",
                         "is-stream": "1.1.0",
-                        "lowercase-keys": "1.0.0",
-                        "safe-buffer": "5.1.1",
+                        "lowercase-keys": "1.0.1",
+                        "safe-buffer": "5.1.2",
                         "timed-out": "4.0.1",
                         "unzip-response": "2.0.1",
                         "url-parse-lax": "1.0.0"
@@ -4213,7 +6454,7 @@
                           "bundled": true
                         },
                         "lowercase-keys": {
-                          "version": "1.0.0",
+                          "version": "1.0.1",
                           "bundled": true
                         },
                         "timed-out": {
@@ -4240,25 +6481,25 @@
                       }
                     },
                     "registry-auth-token": {
-                      "version": "3.3.1",
+                      "version": "3.3.2",
                       "bundled": true,
                       "requires": {
-                        "rc": "1.2.1",
-                        "safe-buffer": "5.1.1"
+                        "rc": "1.2.7",
+                        "safe-buffer": "5.1.2"
                       },
                       "dependencies": {
                         "rc": {
-                          "version": "1.2.1",
+                          "version": "1.2.7",
                           "bundled": true,
                           "requires": {
-                            "deep-extend": "0.4.2",
-                            "ini": "1.3.4",
+                            "deep-extend": "0.5.1",
+                            "ini": "1.3.5",
                             "minimist": "1.2.0",
                             "strip-json-comments": "2.0.1"
                           },
                           "dependencies": {
                             "deep-extend": {
-                              "version": "0.4.2",
+                              "version": "0.5.1",
                               "bundled": true
                             },
                             "minimist": {
@@ -4277,21 +6518,21 @@
                       "version": "3.1.0",
                       "bundled": true,
                       "requires": {
-                        "rc": "1.2.1"
+                        "rc": "1.2.7"
                       },
                       "dependencies": {
                         "rc": {
-                          "version": "1.2.1",
+                          "version": "1.2.7",
                           "bundled": true,
                           "requires": {
-                            "deep-extend": "0.4.2",
-                            "ini": "1.3.4",
+                            "deep-extend": "0.5.1",
+                            "ini": "1.3.5",
                             "minimist": "1.2.0",
                             "strip-json-comments": "2.0.1"
                           },
                           "dependencies": {
                             "deep-extend": {
-                              "version": "0.4.2",
+                              "version": "0.5.1",
                               "bundled": true
                             },
                             "minimist": {
@@ -4314,7 +6555,7 @@
               "version": "2.1.0",
               "bundled": true,
               "requires": {
-                "semver": "5.4.1"
+                "semver": "5.5.0"
               }
             },
             "xdg-basedir": {
@@ -4324,33 +6565,48 @@
           }
         },
         "uuid": {
-          "version": "3.1.0",
+          "version": "3.2.1",
           "bundled": true
         },
         "validate-npm-package-license": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
+            "spdx-correct": "3.0.0",
+            "spdx-expression-parse": "3.0.0"
           },
           "dependencies": {
             "spdx-correct": {
-              "version": "1.0.2",
+              "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "spdx-license-ids": "1.2.2"
+                "spdx-expression-parse": "3.0.0",
+                "spdx-license-ids": "3.0.0"
               },
               "dependencies": {
                 "spdx-license-ids": {
-                  "version": "1.2.2",
+                  "version": "3.0.0",
                   "bundled": true
                 }
               }
             },
             "spdx-expression-parse": {
-              "version": "1.0.4",
-              "bundled": true
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "spdx-exceptions": "2.1.0",
+                "spdx-license-ids": "3.0.0"
+              },
+              "dependencies": {
+                "spdx-exceptions": {
+                  "version": "2.1.0",
+                  "bundled": true
+                },
+                "spdx-license-ids": {
+                  "version": "3.0.0",
+                  "bundled": true
+                }
+              }
             }
           }
         },
@@ -4381,29 +6637,24 @@
           }
         },
         "worker-farm": {
-          "version": "1.5.0",
+          "version": "1.6.0",
           "bundled": true,
           "requires": {
-            "errno": "0.1.4",
-            "xtend": "4.0.1"
+            "errno": "0.1.7"
           },
           "dependencies": {
             "errno": {
-              "version": "0.1.4",
+              "version": "0.1.7",
               "bundled": true,
               "requires": {
-                "prr": "0.0.0"
+                "prr": "1.0.1"
               },
               "dependencies": {
                 "prr": {
-                  "version": "0.0.0",
+                  "version": "1.0.1",
                   "bundled": true
                 }
               }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "bundled": true
             }
           }
         },
@@ -4412,43 +6663,50 @@
           "bundled": true
         },
         "write-file-atomic": {
-          "version": "2.1.0",
+          "version": "2.3.0",
           "bundled": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
+            "signal-exit": "3.0.2"
+          },
+          "dependencies": {
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true
+            }
           }
         }
       }
     },
     "npm-package-arg": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.2.tgz",
-      "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
+      "integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "osenv": "0.1.4",
-        "semver": "5.4.1",
+        "hosted-git-info": "2.6.0",
+        "osenv": "0.1.5",
+        "semver": "5.5.0",
         "validate-npm-package-name": "3.0.0"
       }
     },
     "npm-registry-client": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.4.0.tgz",
-      "integrity": "sha512-PVNfqq0lyRdFnE//nDmn3CC9uqTsr8Bya9KPLIevlXMfkP0m4RpCVyFFk0W1Gfx436kKwyhLA6J+lV+rgR81gQ==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.5.1.tgz",
+      "integrity": "sha512-7rjGF2eA7hKDidGyEWmHTiKfXkbrcQAsGL/Rh4Rt3x3YNRNHhwaTzVJfW3aNvvlhg4G62VCluif0sLCb/i51Hg==",
       "requires": {
-        "concat-stream": "1.6.0",
+        "concat-stream": "1.6.2",
         "graceful-fs": "4.1.11",
         "normalize-package-data": "2.4.0",
-        "npm-package-arg": "5.1.2",
+        "npm-package-arg": "6.1.0",
         "npmlog": "4.1.2",
         "once": "1.4.0",
-        "request": "2.83.0",
+        "request": "2.87.0",
         "retry": "0.10.1",
-        "semver": "5.4.1",
+        "safe-buffer": "5.1.1",
+        "semver": "5.5.0",
         "slide": "1.1.6",
-        "ssri": "4.1.6"
+        "ssri": "5.3.0"
       }
     },
     "npm-run-path": {
@@ -4465,11 +6723,16 @@
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "optional": true,
       "requires": {
-        "are-we-there-yet": "1.1.4",
+        "are-we-there-yet": "1.1.5",
         "console-control-strings": "1.1.0",
         "gauge": "2.7.4",
         "set-blocking": "2.0.0"
       }
+    },
+    "nprogress": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
+      "integrity": "sha1-y480xTIT2JVyP8urkH6UIq28r7E="
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -4544,9 +6807,9 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "requires": {
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
@@ -4558,25 +6821,25 @@
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "requires": {
+        "p-try": "1.0.0"
+      }
     },
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "1.3.0"
       }
     },
-    "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "requires": {
-        "error-ex": "1.3.1"
-      }
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
     "parseqs": {
       "version": "0.0.5",
@@ -4641,14 +6904,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
-    "path-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-      "requires": {
-        "pify": "2.3.0"
-      }
-    },
     "pause": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
@@ -4659,31 +6914,27 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
-    "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-    },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "property-accessors": {
-      "version": "https://registry.npmjs.org/property-accessors/-/property-accessors-1.1.3.tgz",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/property-accessors/-/property-accessors-1.1.3.tgz",
       "integrity": "sha1-Hd6EAkYxhlkJ7zBwM2VoDF+SixU=",
       "requires": {
-        "es6-weak-map": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
-        "mixto": "https://registry.npmjs.org/mixto/-/mixto-1.0.0.tgz"
+        "es6-weak-map": "0.1.4",
+        "mixto": "1.0.0"
       }
     },
     "proxy-addr": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
-      "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+      "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
       "requires": {
         "forwarded": "0.1.2",
-        "ipaddr.js": "1.4.0"
+        "ipaddr.js": "1.6.0"
       }
     },
     "pseudomap": {
@@ -4697,9 +6948,9 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "random-bytes": {
       "version": "1.0.0",
@@ -4712,14 +6963,13 @@
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
     "raven": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/raven/-/raven-2.1.2.tgz",
-      "integrity": "sha512-pBopqPVAuzEP5jyyqEPxJvXg788dAJ9p8NXoHVLF598Ih7MApu2AWT/QHNk2Fa4Rx/xV9yTYDEtAujLXX1FvRg==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.3.tgz",
+      "integrity": "sha512-bKre7qlDW+y1+G2bUtCuntdDYc8o5v1T233t0vmJfbj8ttGOgLrGRlYB8saelVMW9KUAJNLrhFkAKOwFWFJonw==",
       "requires": {
         "cookie": "0.3.1",
-        "json-stringify-safe": "5.0.1",
-        "lsmod": "1.0.0",
-        "stack-trace": "0.0.9",
+        "md5": "2.2.1",
+        "stack-trace": "0.0.10",
         "timed-out": "4.0.1",
         "uuid": "3.0.0"
       },
@@ -4732,22 +6982,22 @@
       }
     },
     "raw-body": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
       "requires": {
         "bytes": "3.0.0",
-        "http-errors": "1.6.2",
-        "iconv-lite": "0.4.19",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
         "unpipe": "1.0.0"
       }
     },
     "rc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
-      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "requires": {
-        "deep-extend": "0.4.2",
+        "deep-extend": "0.6.0",
         "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
@@ -4758,25 +7008,6 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
-      }
-    },
-    "read-pkg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-      "requires": {
-        "load-json-file": "2.0.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "2.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-      "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
       }
     },
     "readable-stream": {
@@ -4796,38 +7027,36 @@
       "integrity": "sha1-4Mk1QsV0UhvqE98PlIjtgqt3xdo="
     },
     "request": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "version": "2.87.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "requires": {
         "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
+        "aws4": "1.7.0",
         "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
+        "combined-stream": "1.0.6",
         "extend": "3.0.1",
         "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
+        "form-data": "2.3.2",
         "har-validator": "5.0.3",
-        "hawk": "6.0.2",
         "http-signature": "1.2.0",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
+        "mime-types": "2.1.18",
         "oauth-sign": "0.8.2",
         "performance-now": "2.1.0",
-        "qs": "6.5.1",
+        "qs": "6.5.2",
         "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
+        "tough-cookie": "2.3.4",
         "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "uuid": "3.2.1"
       },
       "dependencies": {
         "combined-stream": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "requires": {
             "delayed-stream": "1.0.0"
           }
@@ -4843,13 +7072,13 @@
           "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
         },
         "form-data": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "requires": {
             "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
           }
         }
       }
@@ -4882,47 +7111,52 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "send": {
-      "version": "0.15.6",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.15.6.tgz",
-      "integrity": "sha1-IPI6nJJbdiq4JwX+L52yUqzkfjQ=",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.1",
+        "depd": "1.1.2",
         "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.2",
-        "mime": "1.3.4",
+        "http-errors": "1.6.3",
+        "mime": "1.4.1",
         "ms": "2.0.0",
         "on-finished": "2.3.0",
         "range-parser": "1.2.0",
-        "statuses": "1.3.1"
+        "statuses": "1.4.0"
       },
       "dependencies": {
         "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
         }
       }
     },
     "serve-static": {
-      "version": "1.12.6",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.6.tgz",
-      "integrity": "sha1-uXN3P2NEmTTaVOW+ul4x2fQhFXc=",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "requires": {
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "parseurl": "1.3.2",
-        "send": "0.15.6"
+        "send": "0.16.2"
       }
     },
     "set-blocking": {
@@ -4931,9 +7165,9 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "setprototypeof": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -4963,7 +7197,7 @@
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "requires": {
-        "is-arrayish": "0.3.1"
+        "is-arrayish": "0.3.2"
       }
     },
     "slide": {
@@ -4979,24 +7213,27 @@
         "eve": "0.5.4"
       }
     },
-    "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-      "requires": {
-        "hoek": "4.2.0"
-      }
-    },
     "socket.io": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.0.4.tgz",
-      "integrity": "sha1-waRZDO/4fs8TxyZS8Eb3FrKeYBQ=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
+      "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
       "requires": {
-        "debug": "2.6.9",
-        "engine.io": "3.1.4",
+        "debug": "3.1.0",
+        "engine.io": "3.2.0",
+        "has-binary2": "1.0.3",
         "socket.io-adapter": "1.1.1",
-        "socket.io-client": "2.0.4",
-        "socket.io-parser": "3.1.2"
+        "socket.io-client": "2.1.1",
+        "socket.io-parser": "3.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "socket.io-adapter": {
@@ -5005,22 +7242,23 @@
       "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs="
     },
     "socket.io-client": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.0.4.tgz",
-      "integrity": "sha1-CRilUkBtxeVAs4Dc2Xr8SmQzL44=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
+      "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
       "requires": {
         "backo2": "1.0.2",
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "2.6.9",
-        "engine.io-client": "3.1.4",
+        "debug": "3.1.0",
+        "engine.io-client": "3.2.1",
+        "has-binary2": "1.0.3",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "3.1.2",
+        "socket.io-parser": "3.2.0",
         "to-array": "0.1.4"
       },
       "dependencies": {
@@ -5028,17 +7266,24 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
           "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
     "socket.io-parser": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.1.2.tgz",
-      "integrity": "sha1-28IoIVH8T6675Aru3Ady66YZ9/I=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+      "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
       "requires": {
         "component-emitter": "1.2.1",
-        "debug": "2.6.9",
-        "has-binary2": "1.0.2",
+        "debug": "3.1.0",
         "isarray": "2.0.1"
       },
       "dependencies": {
@@ -5046,6 +7291,14 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
           "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "isarray": {
           "version": "2.0.1",
@@ -5055,36 +7308,47 @@
       }
     },
     "space-pen": {
-      "version": "https://registry.npmjs.org/space-pen/-/space-pen-5.1.2.tgz",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/space-pen/-/space-pen-5.1.2.tgz",
       "integrity": "sha1-Ivu+EOCwROe3pHsCPamdlLWE748=",
       "requires": {
-        "grim": "https://registry.npmjs.org/grim/-/grim-1.5.0.tgz",
-        "jquery": "https://registry.npmjs.org/jquery/-/jquery-2.1.4.tgz",
-        "underscore-plus": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.6.6.tgz"
+        "grim": "1.5.0",
+        "jquery": "2.1.4",
+        "underscore-plus": "1.6.8"
       }
     },
     "spdx-correct": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+    },
     "spdx-expression-parse": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "requires": {
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
+      }
     },
     "spdx-license-ids": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
     },
     "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
         "asn1": "0.2.3",
         "assert-plus": "1.0.0",
@@ -5093,26 +7357,27 @@
         "ecc-jsbn": "0.1.1",
         "getpass": "0.1.7",
         "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
         "tweetnacl": "0.14.5"
       }
     },
     "ssri": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz",
-      "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
+      "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
       "requires": {
         "safe-buffer": "5.1.1"
       }
     },
     "stack-trace": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
-      "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU="
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "statuses": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "string-width": {
       "version": "1.0.2",
@@ -5129,11 +7394,6 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
-    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -5141,11 +7401,6 @@
       "requires": {
         "ansi-regex": "2.1.1"
       }
-    },
-    "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -5158,26 +7413,26 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "superagent": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.5.2.tgz",
-      "integrity": "sha1-M2GjlxVnUEw1EGOr6q4PqiPb8/g=",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
       "requires": {
         "component-emitter": "1.2.1",
-        "cookiejar": "2.1.1",
-        "debug": "2.6.9",
+        "cookiejar": "2.1.2",
+        "debug": "3.1.0",
         "extend": "3.0.1",
-        "form-data": "2.3.1",
-        "formidable": "1.1.1",
+        "form-data": "2.3.2",
+        "formidable": "1.2.1",
         "methods": "1.1.2",
-        "mime": "1.3.4",
-        "qs": "6.5.1",
-        "readable-stream": "2.3.3"
+        "mime": "1.4.1",
+        "qs": "6.5.2",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "combined-stream": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "requires": {
             "delayed-stream": "1.0.0"
           }
@@ -5188,9 +7443,17 @@
           "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
         },
         "cookiejar": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
-          "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+          "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "delayed-stream": {
           "version": "1.0.0",
@@ -5203,19 +7466,19 @@
           "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
         },
         "form-data": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "requires": {
             "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
           }
         },
         "formidable": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
-          "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak="
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+          "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
         },
         "isarray": {
           "version": "1.0.0",
@@ -5223,23 +7486,23 @@
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
             "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
+            "process-nextick-args": "2.0.0",
             "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
+            "string_decoder": "1.1.1",
             "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -5273,9 +7536,9 @@
       "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
     },
     "tough-cookie": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
         "punycode": "1.4.1"
       }
@@ -5295,20 +7558,20 @@
       "optional": true
     },
     "type-is": {
-      "version": "1.6.15",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.17"
+        "mime-types": "2.1.18"
       }
     },
     "typechecker": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-4.4.1.tgz",
-      "integrity": "sha1-+XuV9RsDhBchLWd9RaNz7nvO1+Y=",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-4.5.0.tgz",
+      "integrity": "sha512-bqPE/ck3bVIaXP7gMKTKSHrypT32lpYTpiqzPYeYzdSQnmaGvaGhy7TnN/M/+5R+2rs/kKcp9ZLPRp/Q9Yj+4w==",
       "requires": {
-        "editions": "1.3.3"
+        "editions": "1.3.4"
       }
     },
     "typedarray": {
@@ -5330,61 +7593,74 @@
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "underscore": {
-      "version": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
     "underscore-plus": {
-      "version": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.6.6.tgz",
-      "integrity": "sha1-ZezeG9xEGjXYnmUP1w3PE65Dmn0=",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.6.8.tgz",
+      "integrity": "sha512-88PrCeMKeAAC1L4xjSiiZ3Fg6kZOYrLpLGVPPeqKq/662DfQe/KTSKdSR/Q/tucKNnfW2MNAUGSCkDf8HmXC5Q==",
       "requires": {
-        "underscore": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+        "underscore": "1.8.3"
       }
     },
     "ungit": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/ungit/-/ungit-1.3.3.tgz",
-      "integrity": "sha512-uA1giSvANP/nezfosknj0WvJG+b1tRhu/UqZvP+Sqyyk1aSPVlcmzD0tqwubirySrZsYSEleMRPGtF92/fffmg==",
+      "version": "1.4.26",
+      "resolved": "https://registry.npmjs.org/ungit/-/ungit-1.4.26.tgz",
+      "integrity": "sha512-hA1Sr7zi6v+RhcJVC4cOySorCh21+Xdw627ewEkLlRXIWVjUnwdj8cEr0gj6apL7E+lqso3NwhZS/GliMyeL2g==",
       "requires": {
-        "async": "2.5.0",
         "bluebird": "3.5.1",
         "blueimp-md5": "2.10.0",
-        "body-parser": "1.18.2",
-        "color": "2.0.1",
+        "body-parser": "1.18.3",
+        "color": "3.0.0",
         "cookie-parser": "1.4.3",
         "crossroads": "0.12.2",
-        "diff2html": "2.3.2",
-        "express": "4.15.5",
+        "diff2html": "2.3.3",
+        "dnd-page-scroll": "0.0.4",
+        "express": "4.16.3",
         "express-session": "1.15.6",
-        "getmac": "1.2.1",
+        "getmac": "1.4.3",
         "hasher": "1.2.0",
-        "ignore": "3.3.7",
+        "ignore": "3.3.10",
+        "jquery": "3.3.1",
+        "jquery-ui-bundle": "1.12.1",
         "just-detect-adblock": "1.0.0",
-        "keen.io": "0.1.3",
-        "knockout": "3.4.2",
-        "lodash": "4.17.4",
+        "keen.io": "0.1.5",
+        "knockout": "3.5.0-rc",
+        "locks": "0.2.2",
+        "lodash": "4.17.10",
         "memorystore": "1.6.0",
         "mkdirp": "0.5.1",
-        "moment": "2.18.1",
-        "node-cache": "4.1.1",
-        "npm": "5.4.2",
-        "npm-registry-client": "8.4.0",
+        "moment": "2.22.2",
+        "node-cache": "4.2.0",
+        "npm": "6.1.0",
+        "npm-registry-client": "8.5.1",
+        "nprogress": "0.2.0",
         "octicons": "3.5.0",
         "open": "0.0.5",
         "os-homedir": "1.0.2",
         "passport": "0.4.0",
         "passport-local": "1.0.0",
-        "raven": "2.1.2",
-        "rc": "1.2.2",
+        "raven": "2.6.3",
+        "rc": "1.2.8",
         "rimraf": "2.6.2",
-        "semver": "5.4.1",
-        "serve-static": "1.12.6",
+        "semver": "5.5.0",
+        "serve-static": "1.13.2",
         "signals": "1.0.0",
         "snapsvg": "0.5.1",
-        "socket.io": "2.0.4",
-        "superagent": "3.5.2",
+        "socket.io": "2.1.1",
+        "superagent": "3.8.3",
         "temp": "0.8.3",
-        "winston": "2.3.1",
-        "yargs": "9.0.1"
+        "winston": "2.4.3",
+        "yargs": "12.0.0-candidate.0"
+      },
+      "dependencies": {
+        "jquery": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+          "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+        }
       }
     },
     "unpipe": {
@@ -5398,28 +7674,22 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
-    },
-    "uws": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/uws/-/uws-0.14.5.tgz",
-      "integrity": "sha1-Z6rzPEaypYel9mZtAPdpEyjxSdw=",
-      "optional": true
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "validate-npm-package-license": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "validate-npm-package-name": {
@@ -5446,14 +7716,14 @@
       }
     },
     "whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
         "isexe": "2.0.0"
       }
@@ -5464,25 +7734,25 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "wide-align": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "optional": true,
       "requires": {
         "string-width": "1.0.2"
       }
     },
     "winston": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
-      "integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk=",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.3.tgz",
+      "integrity": "sha512-GYKuysPz2pxYAVJD2NPsDLP5Z79SDEzPm9/j4tCjkF/n89iBNGBMJcR+dMUqxgPNgoSs6fVygPi+Vl2oxIpBuw==",
       "requires": {
         "async": "1.0.0",
         "colors": "1.0.3",
         "cycle": "1.0.3",
         "eyes": "0.1.8",
         "isstream": "0.1.2",
-        "stack-trace": "0.0.9"
+        "stack-trace": "0.0.10"
       },
       "dependencies": {
         "async": {
@@ -5507,9 +7777,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.2.tgz",
-      "integrity": "sha512-t+WGpsNxhMR4v6EClXS8r8km5ZljKJzyGhJf7goJz9k5Ye3+b5Bvno5rjqPuIBn5mnn5GBb7o8IrIWHxX1qOLQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "requires": {
         "async-limiter": "1.0.0",
         "safe-buffer": "5.1.1",
@@ -5517,9 +7787,9 @@
       }
     },
     "xmlhttprequest-ssl": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.4.tgz",
-      "integrity": "sha1-BPVgkVcks4kIhxXMDteBPpZ3v1c="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
     },
     "y18n": {
       "version": "3.2.1",
@@ -5532,23 +7802,22 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
-      "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+      "version": "12.0.0-candidate.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.0-candidate.0.tgz",
+      "integrity": "sha512-0bOO0TYTnW97UBp0pJOCFrvsUPZoyRIlIAnGKzCL86cmcuPbgDxxu1X4yjQRrOQemruLzPzfRc4XTFDSW3y/zw==",
       "requires": {
-        "camelcase": "4.1.0",
-        "cliui": "3.2.0",
+        "cliui": "4.1.0",
         "decamelize": "1.2.0",
+        "find-up": "2.1.0",
         "get-caller-file": "1.0.2",
         "os-locale": "2.1.0",
-        "read-pkg-up": "2.0.0",
         "require-directory": "2.1.1",
         "require-main-filename": "1.0.1",
         "set-blocking": "2.0.0",
         "string-width": "2.1.1",
         "which-module": "2.0.0",
         "y18n": "3.2.1",
-        "yargs-parser": "7.0.0"
+        "yargs-parser": "10.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5581,9 +7850,9 @@
       }
     },
     "yargs-parser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.0.0.tgz",
+      "integrity": "sha512-+DHejWujTVYeMHLff8U96rLc4uE4Emncoftvn5AjhB1Jw1pWxLzgBUT/WYbPrHmy6YPEBTZQx5myHhVcuuu64g==",
       "requires": {
         "camelcase": "4.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -417,6 +417,11 @@
         }
       }
     },
+    "connected-domain": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/connected-domain/-/connected-domain-1.0.0.tgz",
+      "integrity": "sha1-v+dyOMdL5FOnnwy2BY3utPI1jpM="
+    },
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -6937,6 +6942,14 @@
         "ipaddr.js": "1.6.0"
       }
     },
+    "ps-node": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ps-node/-/ps-node-0.1.6.tgz",
+      "integrity": "sha1-mvZ6mdex0BMuUaUDCZ04qNKs4sM=",
+      "requires": {
+        "table-parser": "0.1.3"
+      }
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -7507,6 +7520,14 @@
             "safe-buffer": "5.1.1"
           }
         }
+      }
+    },
+    "table-parser": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/table-parser/-/table-parser-0.1.3.tgz",
+      "integrity": "sha1-BEHPzhallIFoTCfRtaZ/8VpDx7A=",
+      "requires": {
+        "connected-domain": "1.0.0"
       }
     },
     "temp": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "atom-space-pen-views": "^2.2.0",
-    "ungit": "^1.4.25"
+    "ungit": "^1.4.25",
+    "ps-node": "~0.1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atom-ungit",
   "main": "./lib/atom-ungit",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Atom package for ungit",
   "activationCommands": {
     "atom-workspace": [
@@ -14,7 +14,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "atom-space-pen-views": "^2.0.5",
-    "ungit": "^1.3.3"
+    "atom-space-pen-views": "^2.2.0",
+    "ungit": "^1.4.25"
   }
 }


### PR DESCRIPTION
If you have installed `atom-ungit` very long time ago, it is possible that a stale dependency from `ungit` caused entire atom to lock up and unable to start up at all.

Actual bug is bit hard to track as nothing starts up and things are blowing up left and right.  It was actually impressive how badly broken it was... haha

this should fix it though